### PR TITLE
AST handling for NumberLiterals

### DIFF
--- a/lib/coffeescript/grammar.js
+++ b/lib/coffeescript/grammar.js
@@ -174,7 +174,10 @@
     AlphaNumeric: [
       o('NUMBER',
       function() {
-        return new NumberLiteral($1);
+        return new NumberLiteral($1.toString(),
+      {
+          parsedValue: $1.parsedValue
+        });
       }),
       o('String')
     ],

--- a/lib/coffeescript/helpers.js
+++ b/lib/coffeescript/helpers.js
@@ -170,7 +170,7 @@
   // Build a dictionary of extra token properties organized by tokens’ locations
   // used as lookup hashes.
   buildTokenDataDictionary = function(parserState) {
-    var base1, i, len1, ref1, token, tokenData, tokenHash;
+    var base, i, len1, ref1, token, tokenData, tokenHash;
     tokenData = {};
     ref1 = parserState.parser.tokens;
     for (i = 0, len1 = ref1.length; i < len1; i++) {
@@ -190,7 +190,7 @@
         // and therefore matching `tokenHash`es, merge the comments from both/all
         // tokens together into one array, even if there are duplicate comments;
         // they will get sorted out later.
-        ((base1 = tokenData[tokenHash]).comments != null ? base1.comments : base1.comments = []).push(...token.comments);
+        ((base = tokenData[tokenHash]).comments != null ? base.comments : base.comments = []).push(...token.comments);
       }
     }
     return tokenData;
@@ -387,37 +387,6 @@
 
   exports.isPlainObject = function(obj) {
     return typeof obj === 'object' && !!obj && !Array.isArray(obj) && !isNumber(obj) && !isString(obj) && !isBoolean(obj);
-  };
-
-  // Converts a number, string, or node (Value/NumberLiteral/unary +/- Op) to its
-  // corresponding number value.
-  exports.getNumberValue = function(number) {
-    var base, invert, val;
-    if (isNumber(number)) {
-      return number;
-    }
-    invert = false;
-    if (!isString(number)) {
-      number = number.unwrap();
-      number = number.operator ? (number.operator === '-' ? invert = true : void 0, number.first.unwrap().value) : number.value;
-    }
-    base = (function() {
-      switch (number.charAt(1)) {
-        case 'b':
-          return 2;
-        case 'o':
-          return 8;
-        case 'x':
-          return 16;
-        default:
-          return null;
-      }
-    })();
-    val = base != null ? parseInt(number.slice(2), base) : parseFloat(number);
-    if (!invert) {
-      return val;
-    }
-    return val * -1;
   };
 
   unicodeCodePointToUnicodeEscapes = function(codePoint) {

--- a/lib/coffeescript/helpers.js
+++ b/lib/coffeescript/helpers.js
@@ -5,7 +5,7 @@
   // arrays, count characters, that sort of thing.
 
   // Peek at the beginning of a given string to see if it matches a sequence.
-  var UNICODE_CODE_POINT_ESCAPE, attachCommentsToNode, buildLocationData, buildLocationHash, buildTokenDataDictionary, extend, flatten, isBoolean, isNumber, isString, ref, repeat, syntaxErrorToString, unicodeCodePointToUnicodeEscapes,
+  var UNICODE_CODE_POINT_ESCAPE, attachCommentsToNode, buildLocationData, buildLocationHash, buildTokenDataDictionary, extend, flatten, getNumberValue, isBoolean, isNumber, isString, ref, repeat, syntaxErrorToString, unicodeCodePointToUnicodeEscapes,
     indexOf = [].indexOf;
 
   exports.starts = function(string, literal, start) {
@@ -391,36 +391,43 @@
 
   // Converts a number, string, or node (Value/NumberLiteral/unary +/- Op) to its
   // corresponding number value.
-  exports.getNumberValue = function(number) {
+  exports.getNumberValue = getNumberValue = function(number) {
     var base, invert, val;
-    if (isNumber(number)) {
-      return number;
+    switch (false) {
+      case !isNumber(number):
+        return number;
+      case !isString(number):
+        base = (function() {
+          switch (number.charAt(1)) {
+            case 'b':
+              return 2;
+            case 'o':
+              return 8;
+            case 'x':
+              return 16;
+            default:
+              return null;
+          }
+        })();
+        if (base != null) {
+          return parseInt(number.slice(2), base);
+        } else {
+          return parseFloat(number);
+        }
+        break;
+      default:
+        number = number.unwrap();
+        if (number.parsedValue != null) {
+          return number.parsedValue;
+        }
+        invert = false;
+        val = getNumberValue(number.operator ? (number.operator === '-' ? invert = true : void 0, number.first) : number.value);
+        if (invert) {
+          return val * -1;
+        } else {
+          return val;
+        }
     }
-    if (number.parsedValue != null) {
-      return number.parsedValue;
-    }
-    invert = false;
-    if (!isString(number)) {
-      number = number.unwrap();
-      number = number.operator ? (number.operator === '-' ? invert = true : void 0, number.first.unwrap().value) : number.value;
-    }
-    base = (function() {
-      switch (number.charAt(1)) {
-        case 'b':
-          return 2;
-        case 'o':
-          return 8;
-        case 'x':
-          return 16;
-        default:
-          return null;
-      }
-    })();
-    val = base != null ? parseInt(number.slice(2), base) : parseFloat(number);
-    if (!invert) {
-      return val;
-    }
-    return val * -1;
   };
 
   unicodeCodePointToUnicodeEscapes = function(codePoint) {

--- a/lib/coffeescript/helpers.js
+++ b/lib/coffeescript/helpers.js
@@ -396,6 +396,9 @@
     if (isNumber(number)) {
       return number;
     }
+    if (number.parsedValue != null) {
+      return number.parsedValue;
+    }
     invert = false;
     if (!isString(number)) {
       number = number.unwrap();

--- a/lib/coffeescript/helpers.js
+++ b/lib/coffeescript/helpers.js
@@ -170,7 +170,7 @@
   // Build a dictionary of extra token properties organized by tokens’ locations
   // used as lookup hashes.
   buildTokenDataDictionary = function(parserState) {
-    var base, i, len1, ref1, token, tokenData, tokenHash;
+    var base1, i, len1, ref1, token, tokenData, tokenHash;
     tokenData = {};
     ref1 = parserState.parser.tokens;
     for (i = 0, len1 = ref1.length; i < len1; i++) {
@@ -190,7 +190,7 @@
         // and therefore matching `tokenHash`es, merge the comments from both/all
         // tokens together into one array, even if there are duplicate comments;
         // they will get sorted out later.
-        ((base = tokenData[tokenHash]).comments != null ? base.comments : base.comments = []).push(...token.comments);
+        ((base1 = tokenData[tokenHash]).comments != null ? base1.comments : base1.comments = []).push(...token.comments);
       }
     }
     return tokenData;
@@ -387,6 +387,37 @@
 
   exports.isPlainObject = function(obj) {
     return typeof obj === 'object' && !!obj && !Array.isArray(obj) && !isNumber(obj) && !isString(obj) && !isBoolean(obj);
+  };
+
+  // Converts a number, string, or node (Value/NumberLiteral/unary +/- Op) to its
+  // corresponding number value.
+  exports.getNumberValue = function(number) {
+    var base, invert, val;
+    if (isNumber(number)) {
+      return number;
+    }
+    invert = false;
+    if (!isString(number)) {
+      number = number.unwrap();
+      number = number.operator ? (number.operator === '-' ? invert = true : void 0, number.first.unwrap().value) : number.value;
+    }
+    base = (function() {
+      switch (number.charAt(1)) {
+        case 'b':
+          return 2;
+        case 'o':
+          return 8;
+        case 'x':
+          return 16;
+        default:
+          return null;
+      }
+    })();
+    val = base != null ? parseInt(number.slice(2), base) : parseFloat(number);
+    if (!invert) {
+      return val;
+    }
+    return val * -1;
   };
 
   unicodeCodePointToUnicodeEscapes = function(codePoint) {

--- a/lib/coffeescript/lexer.js
+++ b/lib/coffeescript/lexer.js
@@ -10,14 +10,14 @@
   // where locationData is {first_line, first_column, last_line, last_column}, which is a
   // format that can be fed directly into [Jison](https://github.com/zaach/jison).  These
   // are read by jison in the `parser.lexer` function defined in coffeescript.coffee.
-  var BOM, BOOL, CALLABLE, CODE, COFFEE_ALIASES, COFFEE_ALIAS_MAP, COFFEE_KEYWORDS, COMMENT, COMPARABLE_LEFT_SIDE, COMPARE, COMPOUND_ASSIGN, CSX_ATTRIBUTE, CSX_FRAGMENT_IDENTIFIER, CSX_IDENTIFIER, CSX_INTERPOLATION, HERECOMMENT_ILLEGAL, HEREDOC_DOUBLE, HEREDOC_INDENT, HEREDOC_SINGLE, HEREGEX, HERE_JSTOKEN, IDENTIFIER, INDENTABLE_CLOSERS, INDEXABLE, INSIDE_CSX, INVERSES, JSTOKEN, JS_KEYWORDS, LINE_BREAK, LINE_CONTINUER, Lexer, MATH, MULTI_DENT, NOT_REGEX, NUMBER, OPERATOR, POSSIBLY_DIVISION, REGEX, REGEX_FLAGS, REGEX_ILLEGAL, REGEX_INVALID_ESCAPE, RELATION, RESERVED, Rewriter, SHIFT, STRICT_PROSCRIBED, STRING_DOUBLE, STRING_INVALID_ESCAPE, STRING_SINGLE, STRING_START, TRAILING_SPACES, UNARY, UNARY_MATH, UNFINISHED, VALID_FLAGS, WHITESPACE, addTokenData, attachCommentsToNode, compact, count, invertLiterate, isForFrom, isUnassignable, key, locationDataToString, merge, repeat, replaceUnicodeCodePointEscapes, starts, throwSyntaxError,
+  var BOM, BOOL, CALLABLE, CODE, COFFEE_ALIASES, COFFEE_ALIAS_MAP, COFFEE_KEYWORDS, COMMENT, COMPARABLE_LEFT_SIDE, COMPARE, COMPOUND_ASSIGN, CSX_ATTRIBUTE, CSX_FRAGMENT_IDENTIFIER, CSX_IDENTIFIER, CSX_INTERPOLATION, HERECOMMENT_ILLEGAL, HEREDOC_DOUBLE, HEREDOC_INDENT, HEREDOC_SINGLE, HEREGEX, HERE_JSTOKEN, IDENTIFIER, INDENTABLE_CLOSERS, INDEXABLE, INSIDE_CSX, INVERSES, JSTOKEN, JS_KEYWORDS, LINE_BREAK, LINE_CONTINUER, Lexer, MATH, MULTI_DENT, NOT_REGEX, NUMBER, OPERATOR, POSSIBLY_DIVISION, REGEX, REGEX_FLAGS, REGEX_ILLEGAL, REGEX_INVALID_ESCAPE, RELATION, RESERVED, Rewriter, SHIFT, STRICT_PROSCRIBED, STRING_DOUBLE, STRING_INVALID_ESCAPE, STRING_SINGLE, STRING_START, TRAILING_SPACES, UNARY, UNARY_MATH, UNFINISHED, VALID_FLAGS, WHITESPACE, addTokenData, attachCommentsToNode, compact, count, getNumberValue, invertLiterate, isForFrom, isUnassignable, key, locationDataToString, merge, repeat, replaceUnicodeCodePointEscapes, starts, throwSyntaxError,
     indexOf = [].indexOf,
     slice = [].slice;
 
   ({Rewriter, INVERSES} = require('./rewriter'));
 
   // Import the helpers we need.
-  ({count, starts, compact, repeat, invertLiterate, merge, attachCommentsToNode, locationDataToString, throwSyntaxError, replaceUnicodeCodePointEscapes} = require('./helpers'));
+  ({count, starts, compact, repeat, invertLiterate, merge, attachCommentsToNode, locationDataToString, throwSyntaxError, replaceUnicodeCodePointEscapes, getNumberValue} = require('./helpers'));
 
   // The Lexer Class
   // ---------------
@@ -282,7 +282,7 @@
     // Matches numbers, including decimals, hex, and exponential notation.
     // Be careful not to interfere with ranges in progress.
     numberToken() {
-      var base, lexedLength, match, number, parsedValue, tag;
+      var lexedLength, match, number, parsedValue, tag;
       if (!(match = NUMBER.exec(this.chunk))) {
         return 0;
       }
@@ -309,19 +309,7 @@
             length: lexedLength
           });
       }
-      base = (function() {
-        switch (number.charAt(1)) {
-          case 'b':
-            return 2;
-          case 'o':
-            return 8;
-          case 'x':
-            return 16;
-          default:
-            return null;
-        }
-      })();
-      parsedValue = base != null ? parseInt(number.slice(2), base) : parseFloat(number);
+      parsedValue = getNumberValue(number);
       tag = parsedValue === 2e308 ? 'INFINITY' : 'NUMBER';
       this.token(tag, number, {
         length: lexedLength,

--- a/lib/coffeescript/lexer.js
+++ b/lib/coffeescript/lexer.js
@@ -10,14 +10,14 @@
   // where locationData is {first_line, first_column, last_line, last_column}, which is a
   // format that can be fed directly into [Jison](https://github.com/zaach/jison).  These
   // are read by jison in the `parser.lexer` function defined in coffeescript.coffee.
-  var BOM, BOOL, CALLABLE, CODE, COFFEE_ALIASES, COFFEE_ALIAS_MAP, COFFEE_KEYWORDS, COMMENT, COMPARABLE_LEFT_SIDE, COMPARE, COMPOUND_ASSIGN, CSX_ATTRIBUTE, CSX_FRAGMENT_IDENTIFIER, CSX_IDENTIFIER, CSX_INTERPOLATION, HERECOMMENT_ILLEGAL, HEREDOC_DOUBLE, HEREDOC_INDENT, HEREDOC_SINGLE, HEREGEX, HERE_JSTOKEN, IDENTIFIER, INDENTABLE_CLOSERS, INDEXABLE, INSIDE_CSX, INVERSES, JSTOKEN, JS_KEYWORDS, LINE_BREAK, LINE_CONTINUER, Lexer, MATH, MULTI_DENT, NOT_REGEX, NUMBER, OPERATOR, POSSIBLY_DIVISION, REGEX, REGEX_FLAGS, REGEX_ILLEGAL, REGEX_INVALID_ESCAPE, RELATION, RESERVED, Rewriter, SHIFT, STRICT_PROSCRIBED, STRING_DOUBLE, STRING_INVALID_ESCAPE, STRING_SINGLE, STRING_START, TRAILING_SPACES, UNARY, UNARY_MATH, UNFINISHED, VALID_FLAGS, WHITESPACE, addTokenData, attachCommentsToNode, compact, count, getNumberValue, invertLiterate, isForFrom, isUnassignable, key, locationDataToString, merge, repeat, replaceUnicodeCodePointEscapes, starts, throwSyntaxError,
+  var BOM, BOOL, CALLABLE, CODE, COFFEE_ALIASES, COFFEE_ALIAS_MAP, COFFEE_KEYWORDS, COMMENT, COMPARABLE_LEFT_SIDE, COMPARE, COMPOUND_ASSIGN, CSX_ATTRIBUTE, CSX_FRAGMENT_IDENTIFIER, CSX_IDENTIFIER, CSX_INTERPOLATION, HERECOMMENT_ILLEGAL, HEREDOC_DOUBLE, HEREDOC_INDENT, HEREDOC_SINGLE, HEREGEX, HERE_JSTOKEN, IDENTIFIER, INDENTABLE_CLOSERS, INDEXABLE, INSIDE_CSX, INVERSES, JSTOKEN, JS_KEYWORDS, LINE_BREAK, LINE_CONTINUER, Lexer, MATH, MULTI_DENT, NOT_REGEX, NUMBER, OPERATOR, POSSIBLY_DIVISION, REGEX, REGEX_FLAGS, REGEX_ILLEGAL, REGEX_INVALID_ESCAPE, RELATION, RESERVED, Rewriter, SHIFT, STRICT_PROSCRIBED, STRING_DOUBLE, STRING_INVALID_ESCAPE, STRING_SINGLE, STRING_START, TRAILING_SPACES, UNARY, UNARY_MATH, UNFINISHED, VALID_FLAGS, WHITESPACE, addTokenData, attachCommentsToNode, compact, count, invertLiterate, isForFrom, isUnassignable, key, locationDataToString, merge, repeat, replaceUnicodeCodePointEscapes, starts, throwSyntaxError,
     indexOf = [].indexOf,
     slice = [].slice;
 
   ({Rewriter, INVERSES} = require('./rewriter'));
 
   // Import the helpers we need.
-  ({count, starts, compact, repeat, invertLiterate, merge, attachCommentsToNode, locationDataToString, throwSyntaxError, replaceUnicodeCodePointEscapes, getNumberValue} = require('./helpers'));
+  ({count, starts, compact, repeat, invertLiterate, merge, attachCommentsToNode, locationDataToString, throwSyntaxError, replaceUnicodeCodePointEscapes} = require('./helpers'));
 
   // The Lexer Class
   // ---------------
@@ -282,7 +282,7 @@
     // Matches numbers, including decimals, hex, and exponential notation.
     // Be careful not to interfere with ranges in progress.
     numberToken() {
-      var lexedLength, match, number, numberValue, tag;
+      var base, lexedLength, match, number, parsedValue, tag;
       if (!(match = NUMBER.exec(this.chunk))) {
         return 0;
       }
@@ -309,10 +309,23 @@
             length: lexedLength
           });
       }
-      numberValue = getNumberValue(number);
-      tag = numberValue === 2e308 ? 'INFINITY' : 'NUMBER';
+      base = (function() {
+        switch (number.charAt(1)) {
+          case 'b':
+            return 2;
+          case 'o':
+            return 8;
+          case 'x':
+            return 16;
+          default:
+            return null;
+        }
+      })();
+      parsedValue = base != null ? parseInt(number.slice(2), base) : parseFloat(number);
+      tag = parsedValue === 2e308 ? 'INFINITY' : 'NUMBER';
       this.token(tag, number, {
-        length: lexedLength
+        length: lexedLength,
+        data: {parsedValue}
       });
       return lexedLength;
     }

--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -4,7 +4,7 @@
   // nodes are created as the result of actions in the [grammar](grammar.html),
   // but some are created by other nodes as a method of code generation. To convert
   // the syntax tree into a string of JavaScript code, call `compile()` on the root.
-  var Access, Arr, Assign, AwaitReturn, Base, Block, BooleanLiteral, CSXTag, Call, Class, Code, CodeFragment, ComputedPropertyName, Elision, ExecutableClassBody, Existence, Expansion, ExportAllDeclaration, ExportDeclaration, ExportDefaultDeclaration, ExportNamedDeclaration, ExportSpecifier, ExportSpecifierList, Extends, For, FuncGlyph, HEREGEX_OMIT, HereComment, HoistTarget, IdentifierLiteral, If, ImportClause, ImportDeclaration, ImportDefaultSpecifier, ImportNamespaceSpecifier, ImportSpecifier, ImportSpecifierList, In, Index, InfinityLiteral, Interpolation, JS_FORBIDDEN, LEADING_BLANK_LINE, LEVEL_ACCESS, LEVEL_COND, LEVEL_LIST, LEVEL_OP, LEVEL_PAREN, LEVEL_TOP, LineComment, Literal, ModuleDeclaration, ModuleSpecifier, ModuleSpecifierList, NEGATE, NO, NaNLiteral, NullLiteral, NumberLiteral, Obj, Op, Param, Parens, PassthroughLiteral, PropertyName, Range, RegexLiteral, RegexWithInterpolations, Return, SIMPLENUM, SIMPLE_STRING_OMIT, STRING_OMIT, Scope, Slice, Splat, StatementLiteral, StringLiteral, StringWithInterpolations, Super, SuperCall, Switch, TAB, THIS, TRAILING_BLANK_LINE, TaggedTemplateCall, ThisLiteral, Throw, Try, UTILITIES, UndefinedLiteral, Value, While, YES, YieldReturn, addDataToNode, astLocationFields, attachCommentsToNode, compact, del, ends, extend, flatten, fragmentsToText, hasLineComments, indentInitial, isFunction, isLiteralArguments, isLiteralThis, isPlainObject, isUnassignable, locationDataToAst, locationDataToString, makeDelimitedLiteral, merge, moveComments, multident, replaceUnicodeCodePointEscapes, shouldCacheOrIsAssignable, some, starts, throwSyntaxError, unfoldSoak, unshiftAfterComments, utility,
+  var Access, Arr, Assign, AwaitReturn, Base, Block, BooleanLiteral, CSXTag, Call, Class, Code, CodeFragment, ComputedPropertyName, Elision, ExecutableClassBody, Existence, Expansion, ExportAllDeclaration, ExportDeclaration, ExportDefaultDeclaration, ExportNamedDeclaration, ExportSpecifier, ExportSpecifierList, Extends, For, FuncGlyph, HEREGEX_OMIT, HereComment, HoistTarget, IdentifierLiteral, If, ImportClause, ImportDeclaration, ImportDefaultSpecifier, ImportNamespaceSpecifier, ImportSpecifier, ImportSpecifierList, In, Index, InfinityLiteral, Interpolation, JS_FORBIDDEN, LEADING_BLANK_LINE, LEVEL_ACCESS, LEVEL_COND, LEVEL_LIST, LEVEL_OP, LEVEL_PAREN, LEVEL_TOP, LineComment, Literal, ModuleDeclaration, ModuleSpecifier, ModuleSpecifierList, NEGATE, NO, NaNLiteral, NullLiteral, NumberLiteral, Obj, Op, Param, Parens, PassthroughLiteral, PropertyName, Range, RegexLiteral, RegexWithInterpolations, Return, SIMPLENUM, SIMPLE_STRING_OMIT, STRING_OMIT, Scope, Slice, Splat, StatementLiteral, StringLiteral, StringWithInterpolations, Super, SuperCall, Switch, TAB, THIS, TRAILING_BLANK_LINE, TaggedTemplateCall, ThisLiteral, Throw, Try, UTILITIES, UndefinedLiteral, Value, While, YES, YieldReturn, addDataToNode, astLocationFields, attachCommentsToNode, compact, del, ends, extend, flatten, fragmentsToText, getNumberValue, hasLineComments, indentInitial, isFunction, isLiteralArguments, isLiteralThis, isNumber, isPlainObject, isUnassignable, locationDataToAst, locationDataToString, makeDelimitedLiteral, merge, moveComments, multident, replaceUnicodeCodePointEscapes, shouldCacheOrIsAssignable, some, starts, throwSyntaxError, unfoldSoak, unshiftAfterComments, utility,
     indexOf = [].indexOf,
     splice = [].splice,
     slice1 = [].slice;
@@ -16,7 +16,7 @@
   ({isUnassignable, JS_FORBIDDEN} = require('./lexer'));
 
   // Import the helpers we plan to use.
-  ({compact, flatten, extend, merge, del, starts, ends, some, addDataToNode, attachCommentsToNode, locationDataToString, throwSyntaxError, replaceUnicodeCodePointEscapes, locationDataToAst, astLocationFields, isFunction, isPlainObject} = require('./helpers'));
+  ({compact, flatten, extend, merge, del, starts, ends, some, addDataToNode, attachCommentsToNode, locationDataToString, throwSyntaxError, replaceUnicodeCodePointEscapes, locationDataToAst, astLocationFields, isFunction, isPlainObject, isNumber, getNumberValue} = require('./helpers'));
 
   // Functions required by parser.
   exports.extend = extend;
@@ -1225,6 +1225,14 @@
         super();
         this.value = value1;
         this.parsedValue = parsedValue;
+        if (this.parsedValue == null) {
+          if (isNumber(this.value)) {
+            this.parsedValue = this.value;
+            this.value = `${this.value}`;
+          } else {
+            this.parsedValue = getNumberValue(this.value);
+          }
+        }
       }
 
       astProps() {
@@ -1232,7 +1240,7 @@
           value: this.parsedValue,
           extra: {
             rawValue: this.parsedValue,
-            raw: `${this.value}`
+            raw: this.value
           }
         };
       }

--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -4,7 +4,7 @@
   // nodes are created as the result of actions in the [grammar](grammar.html),
   // but some are created by other nodes as a method of code generation. To convert
   // the syntax tree into a string of JavaScript code, call `compile()` on the root.
-  var Access, Arr, Assign, AwaitReturn, Base, Block, BooleanLiteral, CSXTag, Call, Class, Code, CodeFragment, ComputedPropertyName, Elision, ExecutableClassBody, Existence, Expansion, ExportAllDeclaration, ExportDeclaration, ExportDefaultDeclaration, ExportNamedDeclaration, ExportSpecifier, ExportSpecifierList, Extends, For, FuncGlyph, HEREGEX_OMIT, HereComment, HoistTarget, IdentifierLiteral, If, ImportClause, ImportDeclaration, ImportDefaultSpecifier, ImportNamespaceSpecifier, ImportSpecifier, ImportSpecifierList, In, Index, InfinityLiteral, Interpolation, JS_FORBIDDEN, LEADING_BLANK_LINE, LEVEL_ACCESS, LEVEL_COND, LEVEL_LIST, LEVEL_OP, LEVEL_PAREN, LEVEL_TOP, LineComment, Literal, ModuleDeclaration, ModuleSpecifier, ModuleSpecifierList, NEGATE, NO, NaNLiteral, NullLiteral, NumberLiteral, Obj, Op, Param, Parens, PassthroughLiteral, PropertyName, Range, RegexLiteral, RegexWithInterpolations, Return, SIMPLENUM, SIMPLE_STRING_OMIT, STRING_OMIT, Scope, Slice, Splat, StatementLiteral, StringLiteral, StringWithInterpolations, Super, SuperCall, Switch, TAB, THIS, TRAILING_BLANK_LINE, TaggedTemplateCall, ThisLiteral, Throw, Try, UTILITIES, UndefinedLiteral, Value, While, YES, YieldReturn, addDataToNode, astLocationFields, attachCommentsToNode, compact, del, ends, extend, flatten, fragmentsToText, getNumberValue, hasLineComments, indentInitial, isFunction, isLiteralArguments, isLiteralThis, isPlainObject, isUnassignable, locationDataToAst, locationDataToString, makeDelimitedLiteral, merge, moveComments, multident, replaceUnicodeCodePointEscapes, shouldCacheOrIsAssignable, some, starts, throwSyntaxError, unfoldSoak, unshiftAfterComments, utility,
+  var Access, Arr, Assign, AwaitReturn, Base, Block, BooleanLiteral, CSXTag, Call, Class, Code, CodeFragment, ComputedPropertyName, Elision, ExecutableClassBody, Existence, Expansion, ExportAllDeclaration, ExportDeclaration, ExportDefaultDeclaration, ExportNamedDeclaration, ExportSpecifier, ExportSpecifierList, Extends, For, FuncGlyph, HEREGEX_OMIT, HereComment, HoistTarget, IdentifierLiteral, If, ImportClause, ImportDeclaration, ImportDefaultSpecifier, ImportNamespaceSpecifier, ImportSpecifier, ImportSpecifierList, In, Index, InfinityLiteral, Interpolation, JS_FORBIDDEN, LEADING_BLANK_LINE, LEVEL_ACCESS, LEVEL_COND, LEVEL_LIST, LEVEL_OP, LEVEL_PAREN, LEVEL_TOP, LineComment, Literal, ModuleDeclaration, ModuleSpecifier, ModuleSpecifierList, NEGATE, NO, NaNLiteral, NullLiteral, NumberLiteral, Obj, Op, Param, Parens, PassthroughLiteral, PropertyName, Range, RegexLiteral, RegexWithInterpolations, Return, SIMPLENUM, SIMPLE_STRING_OMIT, STRING_OMIT, Scope, Slice, Splat, StatementLiteral, StringLiteral, StringWithInterpolations, Super, SuperCall, Switch, TAB, THIS, TRAILING_BLANK_LINE, TaggedTemplateCall, ThisLiteral, Throw, Try, UTILITIES, UndefinedLiteral, Value, While, YES, YieldReturn, addDataToNode, astLocationFields, attachCommentsToNode, compact, del, ends, extend, flatten, fragmentsToText, hasLineComments, indentInitial, isFunction, isLiteralArguments, isLiteralThis, isPlainObject, isUnassignable, locationDataToAst, locationDataToString, makeDelimitedLiteral, merge, moveComments, multident, replaceUnicodeCodePointEscapes, shouldCacheOrIsAssignable, some, starts, throwSyntaxError, unfoldSoak, unshiftAfterComments, utility,
     indexOf = [].indexOf,
     splice = [].splice,
     slice1 = [].slice;
@@ -16,7 +16,7 @@
   ({isUnassignable, JS_FORBIDDEN} = require('./lexer'));
 
   // Import the helpers we plan to use.
-  ({compact, flatten, extend, merge, del, starts, ends, some, addDataToNode, attachCommentsToNode, locationDataToString, throwSyntaxError, replaceUnicodeCodePointEscapes, locationDataToAst, astLocationFields, isFunction, isPlainObject, getNumberValue} = require('./helpers'));
+  ({compact, flatten, extend, merge, del, starts, ends, some, addDataToNode, attachCommentsToNode, locationDataToString, throwSyntaxError, replaceUnicodeCodePointEscapes, locationDataToAst, astLocationFields, isFunction, isPlainObject} = require('./helpers'));
 
   // Functions required by parser.
   exports.extend = extend;
@@ -1221,13 +1221,17 @@
 
   exports.NumberLiteral = NumberLiteral = (function() {
     class NumberLiteral extends Literal {
+      constructor(value1, {parsedValue} = {}) {
+        super();
+        this.value = value1;
+        this.parsedValue = parsedValue;
+      }
+
       astProps() {
-        var numberValue;
-        numberValue = getNumberValue(this.value);
         return {
-          value: numberValue,
+          value: this.parsedValue,
           extra: {
-            rawValue: numberValue,
+            rawValue: this.parsedValue,
             raw: `${this.value}`
           }
         };

--- a/lib/coffeescript/parser.js
+++ b/lib/coffeescript/parser.js
@@ -136,7 +136,11 @@ case 39:
 this.$ = yy.addDataToNode(yy, _$[$0], _$[$0])(new yy.PropertyName($$[$0]));
 break;
 case 40:
-this.$ = yy.addDataToNode(yy, _$[$0], _$[$0])(new yy.NumberLiteral($$[$0]));
+this.$ = yy.addDataToNode(yy, _$[$0], _$[$0])(new yy.NumberLiteral($$[$0].toString(),
+      {
+          base: $$[$0].base,
+          parsedValue: $$[$0].parsedValue
+        }));
 break;
 case 42:
 this.$ = yy.addDataToNode(yy, _$[$0], _$[$0])(new yy.StringLiteral($$[$0].slice(1,

--- a/src/grammar.coffee
+++ b/src/grammar.coffee
@@ -162,7 +162,7 @@ grammar =
   # Alphanumerics are separated from the other **Literal** matchers because
   # they can also serve as keys in object literals.
   AlphaNumeric: [
-    o 'NUMBER',                                 -> new NumberLiteral $1
+    o 'NUMBER',                                 -> new NumberLiteral $1.toString(), parsedValue: $1.parsedValue
     o 'String'
   ]
 

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -273,27 +273,30 @@ exports.isPlainObject = (obj) -> typeof obj is 'object' and !!obj and not Array.
 
 # Converts a number, string, or node (Value/NumberLiteral/unary +/- Op) to its
 # corresponding number value.
-exports.getNumberValue = (number) ->
-  return number if isNumber number
-  return number.parsedValue if number.parsedValue?
-  invert = no
-  unless isString number
-    number = number.unwrap()
-    number =
-      if number.operator
-        invert = yes if number.operator is '-'
-        number.first.unwrap().value
-      else
-        number.value
-  base = switch number.charAt 1
-    when 'b' then 2
-    when 'o' then 8
-    when 'x' then 16
-    else null
+exports.getNumberValue = getNumberValue = (number) ->
+  switch
+    when isNumber number
+      number
+    when isString number
+      base = switch number.charAt 1
+        when 'b' then 2
+        when 'o' then 8
+        when 'x' then 16
+        else null
 
-  val = if base? then parseInt(number[2..], base) else parseFloat(number)
-  return val unless invert
-  val * -1
+      if base? then parseInt(number[2..], base) else parseFloat(number)
+    else
+      number = number.unwrap()
+      return number.parsedValue if number.parsedValue?
+      invert = no
+      val = getNumberValue(
+        if number.operator
+          invert = yes if number.operator is '-'
+          number.first
+        else
+          number.value
+      )
+      if invert then val * -1 else val
 
 unicodeCodePointToUnicodeEscapes = (codePoint) ->
   toUnicodeEscape = (val) ->

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -271,29 +271,6 @@ exports.isString = isString = (obj) -> Object::toString.call(obj) is '[object St
 exports.isBoolean = isBoolean = (obj) -> obj is yes or obj is no or Object::toString.call(obj) is '[object Boolean]'
 exports.isPlainObject = (obj) -> typeof obj is 'object' and !!obj and not Array.isArray(obj) and not isNumber(obj) and not isString(obj) and not isBoolean(obj)
 
-# Converts a number, string, or node (Value/NumberLiteral/unary +/- Op) to its
-# corresponding number value.
-exports.getNumberValue = (number) ->
-  return number if isNumber number
-  invert = no
-  unless isString number
-    number = number.unwrap()
-    number =
-      if number.operator
-        invert = yes if number.operator is '-'
-        number.first.unwrap().value
-      else
-        number.value
-  base = switch number.charAt 1
-    when 'b' then 2
-    when 'o' then 8
-    when 'x' then 16
-    else null
-
-  val = if base? then parseInt(number[2..], base) else parseFloat(number)
-  return val unless invert
-  val * -1
-
 unicodeCodePointToUnicodeEscapes = (codePoint) ->
   toUnicodeEscape = (val) ->
     str = val.toString 16

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -271,6 +271,29 @@ exports.isString = isString = (obj) -> Object::toString.call(obj) is '[object St
 exports.isBoolean = isBoolean = (obj) -> obj is yes or obj is no or Object::toString.call(obj) is '[object Boolean]'
 exports.isPlainObject = (obj) -> typeof obj is 'object' and !!obj and not Array.isArray(obj) and not isNumber(obj) and not isString(obj) and not isBoolean(obj)
 
+# Converts a number, string, or node (Value/NumberLiteral/unary +/- Op) to its
+# corresponding number value.
+exports.getNumberValue = (number) ->
+  return number if isNumber number
+  invert = no
+  unless isString number
+    number = number.unwrap()
+    number =
+      if number.operator
+        invert = yes if number.operator is '-'
+        number.first.unwrap().value
+      else
+        number.value
+  base = switch number.charAt 1
+    when 'b' then 2
+    when 'o' then 8
+    when 'x' then 16
+    else null
+
+  val = if base? then parseInt(number[2..], base) else parseFloat(number)
+  return val unless invert
+  val * -1
+
 unicodeCodePointToUnicodeEscapes = (codePoint) ->
   toUnicodeEscape = (val) ->
     str = val.toString 16

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -275,6 +275,7 @@ exports.isPlainObject = (obj) -> typeof obj is 'object' and !!obj and not Array.
 # corresponding number value.
 exports.getNumberValue = (number) ->
   return number if isNumber number
+  return number.parsedValue if number.parsedValue?
   invert = no
   unless isString number
     number = number.unwrap()

--- a/src/lexer.coffee
+++ b/src/lexer.coffee
@@ -14,7 +14,7 @@
 # Import the helpers we need.
 {count, starts, compact, repeat, invertLiterate, merge,
 attachCommentsToNode, locationDataToString, throwSyntaxError
-replaceUnicodeCodePointEscapes} = require './helpers'
+replaceUnicodeCodePointEscapes, getNumberValue} = require './helpers'
 
 # The Lexer Class
 # ---------------
@@ -258,13 +258,7 @@ exports.Lexer = class Lexer
       when /^0\d+/.test number
         @error "octal literal '#{number}' must be prefixed with '0o'", length: lexedLength
 
-    base = switch number.charAt 1
-      when 'b' then 2
-      when 'o' then 8
-      when 'x' then 16
-      else null
-
-    parsedValue = if base? then parseInt(number[2..], base) else parseFloat(number)
+    parsedValue = getNumberValue number
 
     tag = if parsedValue is Infinity then 'INFINITY' else 'NUMBER'
     @token tag, number,

--- a/src/lexer.coffee
+++ b/src/lexer.coffee
@@ -14,7 +14,7 @@
 # Import the helpers we need.
 {count, starts, compact, repeat, invertLiterate, merge,
 attachCommentsToNode, locationDataToString, throwSyntaxError
-replaceUnicodeCodePointEscapes, getNumberValue} = require './helpers'
+replaceUnicodeCodePointEscapes} = require './helpers'
 
 # The Lexer Class
 # ---------------
@@ -258,10 +258,18 @@ exports.Lexer = class Lexer
       when /^0\d+/.test number
         @error "octal literal '#{number}' must be prefixed with '0o'", length: lexedLength
 
-    numberValue = getNumberValue number
+    base = switch number.charAt 1
+      when 'b' then 2
+      when 'o' then 8
+      when 'x' then 16
+      else null
 
-    tag = if numberValue is Infinity then 'INFINITY' else 'NUMBER'
-    @token tag, number, length: lexedLength
+    parsedValue = if base? then parseInt(number[2..], base) else parseFloat(number)
+
+    tag = if parsedValue is Infinity then 'INFINITY' else 'NUMBER'
+    @token tag, number,
+      length: lexedLength
+      data: {parsedValue}
     lexedLength
 
   # Matches strings, including multiline strings, as well as heredocs, with or without

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -13,9 +13,7 @@ Error.stackTraceLimit = Infinity
 addDataToNode, attachCommentsToNode, locationDataToString,
 throwSyntaxError, replaceUnicodeCodePointEscapes,
 locationDataToAst, astLocationFields,
-isFunction, isPlainObject,
-getNumberValue,
-} = require './helpers'
+isFunction, isPlainObject} = require './helpers'
 
 # Functions required by parser.
 exports.extend = extend
@@ -843,13 +841,14 @@ exports.Literal = class Literal extends Base
     " #{if @isStatement() then super() else @constructor.name}: #{@value}"
 
 exports.NumberLiteral = class NumberLiteral extends Literal
+  constructor: (@value, {@parsedValue} = {}) ->
+    super()
+
   astType: 'NumericLiteral'
   astProps: ->
-    numberValue = getNumberValue @value
-
-    value: numberValue
+    value: @parsedValue
     extra:
-      rawValue: numberValue
+      rawValue: @parsedValue
       raw: "#{@value}"
 
 exports.InfinityLiteral = class InfinityLiteral extends NumberLiteral

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -13,7 +13,9 @@ Error.stackTraceLimit = Infinity
 addDataToNode, attachCommentsToNode, locationDataToString,
 throwSyntaxError, replaceUnicodeCodePointEscapes,
 locationDataToAst, astLocationFields,
-isFunction, isPlainObject} = require './helpers'
+isFunction, isPlainObject, isNumber,
+getNumberValue,
+} = require './helpers'
 
 # Functions required by parser.
 exports.extend = extend
@@ -843,13 +845,19 @@ exports.Literal = class Literal extends Base
 exports.NumberLiteral = class NumberLiteral extends Literal
   constructor: (@value, {@parsedValue} = {}) ->
     super()
+    unless @parsedValue?
+      if isNumber @value
+        @parsedValue = @value
+        @value = "#{@value}"
+      else
+        @parsedValue = getNumberValue @value
 
   astType: 'NumericLiteral'
   astProps: ->
     value: @parsedValue
     extra:
       rawValue: @parsedValue
-      raw: "#{@value}"
+      raw: @value
 
 exports.InfinityLiteral = class InfinityLiteral extends NumberLiteral
   compileNode: ->

--- a/test/abstract_syntax_tree.coffee
+++ b/test/abstract_syntax_tree.coffee
@@ -78,6 +78,13 @@ test "AST as expected for NumberLiteral node", ->
       rawValue: 42
       raw: '42'
 
+  testExpression '0xE1',
+    type: 'NumericLiteral'
+    value: 225
+    extra:
+      rawValue: 225
+      raw: '0xE1'
+
 test "AST as expected for InfinityLiteral node", ->
   testExpression 'Infinity',
     type: 'Identifier'


### PR DESCRIPTION
So I was staring at `getNumberValue`, and I noticed that it was checking for positive or negative; but the `-` sign is a different token/node, `Op`, and never part of `NumberLiteral`. So I restored the previous code in the lexer that had become `getNumberValue`, and passed through the parsed number value from the lexer to the node class.