### PR TITLE
Numbers

### DIFF
--- a/lib/coffeescript/helpers.js
+++ b/lib/coffeescript/helpers.js
@@ -170,7 +170,7 @@
   // Build a dictionary of extra token properties organized by tokens’ locations
   // used as lookup hashes.
   buildTokenDataDictionary = function(parserState) {
-    var base1, i, len1, ref1, token, tokenData, tokenHash;
+    var base, i, len1, ref1, token, tokenData, tokenHash;
     tokenData = {};
     ref1 = parserState.parser.tokens;
     for (i = 0, len1 = ref1.length; i < len1; i++) {
@@ -190,7 +190,7 @@
         // and therefore matching `tokenHash`es, merge the comments from both/all
         // tokens together into one array, even if there are duplicate comments;
         // they will get sorted out later.
-        ((base1 = tokenData[tokenHash]).comments != null ? base1.comments : base1.comments = []).push(...token.comments);
+        ((base = tokenData[tokenHash]).comments != null ? base.comments : base.comments = []).push(...token.comments);
       }
     }
     return tokenData;
@@ -387,28 +387,6 @@
 
   exports.isPlainObject = function(obj) {
     return typeof obj === 'object' && !!obj && !Array.isArray(obj) && !isNumber(obj) && !isString(obj) && !isBoolean(obj);
-  };
-
-  // Converts a string to its corresponding number value.
-  exports.parseNumber = function(str) {
-    var base;
-    base = (function() {
-      switch (str.charAt(1)) {
-        case 'b':
-          return 2;
-        case 'o':
-          return 8;
-        case 'x':
-          return 16;
-        default:
-          return null;
-      }
-    })();
-    if (base != null) {
-      return parseInt(str.slice(2), base);
-    } else {
-      return parseFloat(str);
-    }
   };
 
   unicodeCodePointToUnicodeEscapes = function(codePoint) {

--- a/lib/coffeescript/lexer.js
+++ b/lib/coffeescript/lexer.js
@@ -10,14 +10,14 @@
   // where locationData is {first_line, first_column, last_line, last_column}, which is a
   // format that can be fed directly into [Jison](https://github.com/zaach/jison).  These
   // are read by jison in the `parser.lexer` function defined in coffeescript.coffee.
-  var BOM, BOOL, CALLABLE, CODE, COFFEE_ALIASES, COFFEE_ALIAS_MAP, COFFEE_KEYWORDS, COMMENT, COMPARABLE_LEFT_SIDE, COMPARE, COMPOUND_ASSIGN, CSX_ATTRIBUTE, CSX_FRAGMENT_IDENTIFIER, CSX_IDENTIFIER, CSX_INTERPOLATION, HERECOMMENT_ILLEGAL, HEREDOC_DOUBLE, HEREDOC_INDENT, HEREDOC_SINGLE, HEREGEX, HERE_JSTOKEN, IDENTIFIER, INDENTABLE_CLOSERS, INDEXABLE, INSIDE_CSX, INVERSES, JSTOKEN, JS_KEYWORDS, LINE_BREAK, LINE_CONTINUER, Lexer, MATH, MULTI_DENT, NOT_REGEX, NUMBER, OPERATOR, POSSIBLY_DIVISION, REGEX, REGEX_FLAGS, REGEX_ILLEGAL, REGEX_INVALID_ESCAPE, RELATION, RESERVED, Rewriter, SHIFT, STRICT_PROSCRIBED, STRING_DOUBLE, STRING_INVALID_ESCAPE, STRING_SINGLE, STRING_START, TRAILING_SPACES, UNARY, UNARY_MATH, UNFINISHED, VALID_FLAGS, WHITESPACE, addTokenData, attachCommentsToNode, compact, count, invertLiterate, isForFrom, isUnassignable, key, locationDataToString, merge, parseNumber, repeat, replaceUnicodeCodePointEscapes, starts, throwSyntaxError,
+  var BOM, BOOL, CALLABLE, CODE, COFFEE_ALIASES, COFFEE_ALIAS_MAP, COFFEE_KEYWORDS, COMMENT, COMPARABLE_LEFT_SIDE, COMPARE, COMPOUND_ASSIGN, CSX_ATTRIBUTE, CSX_FRAGMENT_IDENTIFIER, CSX_IDENTIFIER, CSX_INTERPOLATION, HERECOMMENT_ILLEGAL, HEREDOC_DOUBLE, HEREDOC_INDENT, HEREDOC_SINGLE, HEREGEX, HERE_JSTOKEN, IDENTIFIER, INDENTABLE_CLOSERS, INDEXABLE, INSIDE_CSX, INVERSES, JSTOKEN, JS_KEYWORDS, LINE_BREAK, LINE_CONTINUER, Lexer, MATH, MULTI_DENT, NOT_REGEX, NUMBER, OPERATOR, POSSIBLY_DIVISION, REGEX, REGEX_FLAGS, REGEX_ILLEGAL, REGEX_INVALID_ESCAPE, RELATION, RESERVED, Rewriter, SHIFT, STRICT_PROSCRIBED, STRING_DOUBLE, STRING_INVALID_ESCAPE, STRING_SINGLE, STRING_START, TRAILING_SPACES, UNARY, UNARY_MATH, UNFINISHED, VALID_FLAGS, WHITESPACE, addTokenData, attachCommentsToNode, compact, count, invertLiterate, isForFrom, isUnassignable, key, locationDataToString, merge, repeat, replaceUnicodeCodePointEscapes, starts, throwSyntaxError,
     indexOf = [].indexOf,
     slice = [].slice;
 
   ({Rewriter, INVERSES} = require('./rewriter'));
 
   // Import the helpers we need.
-  ({count, starts, compact, repeat, invertLiterate, merge, attachCommentsToNode, locationDataToString, throwSyntaxError, replaceUnicodeCodePointEscapes, parseNumber} = require('./helpers'));
+  ({count, starts, compact, repeat, invertLiterate, merge, attachCommentsToNode, locationDataToString, throwSyntaxError, replaceUnicodeCodePointEscapes} = require('./helpers'));
 
   // The Lexer Class
   // ---------------
@@ -309,8 +309,8 @@
             length: lexedLength
           });
       }
-      parsedValue = parseNumber(number);
-      tag = parsedValue === 2e308 ? 'INFINITY' : 'NUMBER';
+      parsedValue = Number(number);
+      tag = Number.isFinite(parsedValue) ? 'NUMBER' : 'INFINITY';
       this.token(tag, number, {
         length: lexedLength,
         data: {parsedValue}

--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -4,7 +4,7 @@
   // nodes are created as the result of actions in the [grammar](grammar.html),
   // but some are created by other nodes as a method of code generation. To convert
   // the syntax tree into a string of JavaScript code, call `compile()` on the root.
-  var Access, Arr, Assign, AwaitReturn, Base, Block, BooleanLiteral, CSXTag, Call, Class, Code, CodeFragment, ComputedPropertyName, Elision, ExecutableClassBody, Existence, Expansion, ExportAllDeclaration, ExportDeclaration, ExportDefaultDeclaration, ExportNamedDeclaration, ExportSpecifier, ExportSpecifierList, Extends, For, FuncGlyph, HEREGEX_OMIT, HereComment, HoistTarget, IdentifierLiteral, If, ImportClause, ImportDeclaration, ImportDefaultSpecifier, ImportNamespaceSpecifier, ImportSpecifier, ImportSpecifierList, In, Index, InfinityLiteral, Interpolation, JS_FORBIDDEN, LEADING_BLANK_LINE, LEVEL_ACCESS, LEVEL_COND, LEVEL_LIST, LEVEL_OP, LEVEL_PAREN, LEVEL_TOP, LineComment, Literal, ModuleDeclaration, ModuleSpecifier, ModuleSpecifierList, NEGATE, NO, NaNLiteral, NullLiteral, NumberLiteral, Obj, Op, Param, Parens, PassthroughLiteral, PropertyName, Range, RegexLiteral, RegexWithInterpolations, Return, SIMPLENUM, SIMPLE_STRING_OMIT, STRING_OMIT, Scope, Slice, Splat, StatementLiteral, StringLiteral, StringWithInterpolations, Super, SuperCall, Switch, TAB, THIS, TRAILING_BLANK_LINE, TaggedTemplateCall, ThisLiteral, Throw, Try, UTILITIES, UndefinedLiteral, Value, While, YES, YieldReturn, addDataToNode, astLocationFields, attachCommentsToNode, compact, del, ends, extend, flatten, fragmentsToText, hasLineComments, indentInitial, isFunction, isLiteralArguments, isLiteralThis, isNumber, isPlainObject, isUnassignable, locationDataToAst, locationDataToString, makeDelimitedLiteral, merge, moveComments, multident, parseNumber, replaceUnicodeCodePointEscapes, shouldCacheOrIsAssignable, some, starts, throwSyntaxError, unfoldSoak, unshiftAfterComments, utility,
+  var Access, Arr, Assign, AwaitReturn, Base, Block, BooleanLiteral, CSXTag, Call, Class, Code, CodeFragment, ComputedPropertyName, Elision, ExecutableClassBody, Existence, Expansion, ExportAllDeclaration, ExportDeclaration, ExportDefaultDeclaration, ExportNamedDeclaration, ExportSpecifier, ExportSpecifierList, Extends, For, FuncGlyph, HEREGEX_OMIT, HereComment, HoistTarget, IdentifierLiteral, If, ImportClause, ImportDeclaration, ImportDefaultSpecifier, ImportNamespaceSpecifier, ImportSpecifier, ImportSpecifierList, In, Index, InfinityLiteral, Interpolation, JS_FORBIDDEN, LEADING_BLANK_LINE, LEVEL_ACCESS, LEVEL_COND, LEVEL_LIST, LEVEL_OP, LEVEL_PAREN, LEVEL_TOP, LineComment, Literal, ModuleDeclaration, ModuleSpecifier, ModuleSpecifierList, NEGATE, NO, NaNLiteral, NullLiteral, NumberLiteral, Obj, Op, Param, Parens, PassthroughLiteral, PropertyName, Range, RegexLiteral, RegexWithInterpolations, Return, SIMPLENUM, SIMPLE_STRING_OMIT, STRING_OMIT, Scope, Slice, Splat, StatementLiteral, StringLiteral, StringWithInterpolations, Super, SuperCall, Switch, TAB, THIS, TRAILING_BLANK_LINE, TaggedTemplateCall, ThisLiteral, Throw, Try, UTILITIES, UndefinedLiteral, Value, While, YES, YieldReturn, addDataToNode, astLocationFields, attachCommentsToNode, compact, del, ends, extend, flatten, fragmentsToText, hasLineComments, indentInitial, isFunction, isLiteralArguments, isLiteralThis, isNumber, isPlainObject, isUnassignable, locationDataToAst, locationDataToString, makeDelimitedLiteral, merge, moveComments, multident, replaceUnicodeCodePointEscapes, shouldCacheOrIsAssignable, some, starts, throwSyntaxError, unfoldSoak, unshiftAfterComments, utility,
     indexOf = [].indexOf,
     splice = [].splice,
     slice1 = [].slice;
@@ -16,7 +16,7 @@
   ({isUnassignable, JS_FORBIDDEN} = require('./lexer'));
 
   // Import the helpers we plan to use.
-  ({compact, flatten, extend, merge, del, starts, ends, some, addDataToNode, attachCommentsToNode, locationDataToString, throwSyntaxError, replaceUnicodeCodePointEscapes, locationDataToAst, astLocationFields, isFunction, isPlainObject, isNumber, parseNumber} = require('./helpers'));
+  ({compact, flatten, extend, merge, del, starts, ends, some, addDataToNode, attachCommentsToNode, locationDataToString, throwSyntaxError, replaceUnicodeCodePointEscapes, locationDataToAst, astLocationFields, isFunction, isPlainObject, isNumber} = require('./helpers'));
 
   // Functions required by parser.
   exports.extend = extend;
@@ -1230,7 +1230,7 @@
             this.parsedValue = this.value;
             this.value = `${this.value}`;
           } else {
-            this.parsedValue = parseNumber(this.value);
+            this.parsedValue = Number(this.value);
           }
         }
       }

--- a/lib/coffeescript/parser.js
+++ b/lib/coffeescript/parser.js
@@ -138,7 +138,6 @@ break;
 case 40:
 this.$ = yy.addDataToNode(yy, _$[$0], _$[$0])(new yy.NumberLiteral($$[$0].toString(),
       {
-          base: $$[$0].base,
           parsedValue: $$[$0].parsedValue
         }));
 break;

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -271,16 +271,6 @@ exports.isString = isString = (obj) -> Object::toString.call(obj) is '[object St
 exports.isBoolean = isBoolean = (obj) -> obj is yes or obj is no or Object::toString.call(obj) is '[object Boolean]'
 exports.isPlainObject = (obj) -> typeof obj is 'object' and !!obj and not Array.isArray(obj) and not isNumber(obj) and not isString(obj) and not isBoolean(obj)
 
-# Converts a string to its corresponding number value.
-exports.parseNumber = (str) ->
-  base = switch str.charAt 1
-    when 'b' then 2
-    when 'o' then 8
-    when 'x' then 16
-    else null
-
-  if base? then parseInt(str[2..], base) else parseFloat(str)
-
 unicodeCodePointToUnicodeEscapes = (codePoint) ->
   toUnicodeEscape = (val) ->
     str = val.toString 16

--- a/src/lexer.coffee
+++ b/src/lexer.coffee
@@ -14,7 +14,7 @@
 # Import the helpers we need.
 {count, starts, compact, repeat, invertLiterate, merge,
 attachCommentsToNode, locationDataToString, throwSyntaxError
-replaceUnicodeCodePointEscapes, parseNumber} = require './helpers'
+replaceUnicodeCodePointEscapes} = require './helpers'
 
 # The Lexer Class
 # ---------------
@@ -258,9 +258,9 @@ exports.Lexer = class Lexer
       when /^0\d+/.test number
         @error "octal literal '#{number}' must be prefixed with '0o'", length: lexedLength
 
-    parsedValue = parseNumber number
+    parsedValue = Number number
 
-    tag = if parsedValue is Infinity then 'INFINITY' else 'NUMBER'
+    tag = if Number.isFinite(parsedValue) then 'NUMBER' else 'INFINITY'
     @token tag, number,
       length: lexedLength
       data: {parsedValue}

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -13,9 +13,7 @@ Error.stackTraceLimit = Infinity
 addDataToNode, attachCommentsToNode, locationDataToString,
 throwSyntaxError, replaceUnicodeCodePointEscapes,
 locationDataToAst, astLocationFields,
-isFunction, isPlainObject, isNumber,
-parseNumber,
-} = require './helpers'
+isFunction, isPlainObject, isNumber} = require './helpers'
 
 # Functions required by parser.
 exports.extend = extend
@@ -850,7 +848,7 @@ exports.NumberLiteral = class NumberLiteral extends Literal
         @parsedValue = @value
         @value = "#{@value}"
       else
-        @parsedValue = parseNumber @value
+        @parsedValue = Number @value
 
   astType: 'NumericLiteral'
   astProps: ->


### PR DESCRIPTION
So I did a little more reading into this, and the built-in JavaScript global `Number` does a better job at parsing strings into numbers than our function ever will: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number. We should really be using this, it seems to me; and then there’s one less helper to worry about.

I know, I’m a little obsessed, but this will go faster after this first PR I’m sure.