### PR TITLE
AST generation methods refactor

### DIFF
--- a/lib/coffeescript/coffeescript.js
+++ b/lib/coffeescript/coffeescript.js
@@ -129,7 +129,7 @@
     // If all that was requested was a POJO representation of the nodes, e.g.
     // the abstract syntax tree (AST), we can stop now and just return that.
     if (options.ast) {
-      return nodes.toAst(options);
+      return nodes.ast(options);
     }
     fragments = nodes.compileToFragments(options);
     currentLine = 0;

--- a/lib/coffeescript/helpers.js
+++ b/lib/coffeescript/helpers.js
@@ -349,26 +349,6 @@
     }
   };
 
-  exports.locationDataToAst = function({first_line, first_column, last_line, last_column, range}) {
-    return {
-      loc: {
-        start: {
-          line: first_line + 1,
-          column: first_column
-        },
-        end: {
-          line: last_line + 1,
-          column: last_column + 1
-        }
-      },
-      range: [range[0], range[1]],
-      start: range[0],
-      end: range[1]
-    };
-  };
-
-  exports.astLocationFields = ['loc', 'range', 'start', 'end'];
-
   exports.isFunction = function(obj) {
     return Object.prototype.toString.call(obj) === '[object Function]';
   };

--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -4,7 +4,7 @@
   // nodes are created as the result of actions in the [grammar](grammar.html),
   // but some are created by other nodes as a method of code generation. To convert
   // the syntax tree into a string of JavaScript code, call `compile()` on the root.
-  var Access, Arr, Assign, AwaitReturn, Base, Block, BooleanLiteral, CSXTag, Call, Class, Code, CodeFragment, ComputedPropertyName, Elision, ExecutableClassBody, Existence, Expansion, ExportAllDeclaration, ExportDeclaration, ExportDefaultDeclaration, ExportNamedDeclaration, ExportSpecifier, ExportSpecifierList, Extends, For, FuncGlyph, HEREGEX_OMIT, HereComment, HoistTarget, IdentifierLiteral, If, ImportClause, ImportDeclaration, ImportDefaultSpecifier, ImportNamespaceSpecifier, ImportSpecifier, ImportSpecifierList, In, Index, InfinityLiteral, Interpolation, JS_FORBIDDEN, LEADING_BLANK_LINE, LEVEL_ACCESS, LEVEL_COND, LEVEL_LIST, LEVEL_OP, LEVEL_PAREN, LEVEL_TOP, LineComment, Literal, ModuleDeclaration, ModuleSpecifier, ModuleSpecifierList, NEGATE, NO, NaNLiteral, NullLiteral, NumberLiteral, Obj, Op, Param, Parens, PassthroughLiteral, PropertyName, Range, RegexLiteral, RegexWithInterpolations, Return, SIMPLENUM, SIMPLE_STRING_OMIT, STRING_OMIT, Scope, Slice, Splat, StatementLiteral, StringLiteral, StringWithInterpolations, Super, SuperCall, Switch, TAB, THIS, TRAILING_BLANK_LINE, TaggedTemplateCall, ThisLiteral, Throw, Try, UTILITIES, UndefinedLiteral, Value, While, YES, YieldReturn, addDataToNode, astLocationFields, attachCommentsToNode, compact, del, ends, extend, flatten, fragmentsToText, hasLineComments, indentInitial, isFunction, isLiteralArguments, isLiteralThis, isNumber, isPlainObject, isUnassignable, locationDataToAst, locationDataToString, makeDelimitedLiteral, merge, moveComments, multident, replaceUnicodeCodePointEscapes, shouldCacheOrIsAssignable, some, starts, throwSyntaxError, unfoldSoak, unshiftAfterComments, utility,
+  var Access, Arr, Assign, AwaitReturn, Base, Block, BooleanLiteral, CSXTag, Call, Class, Code, CodeFragment, ComputedPropertyName, Elision, ExecutableClassBody, Existence, Expansion, ExportAllDeclaration, ExportDeclaration, ExportDefaultDeclaration, ExportNamedDeclaration, ExportSpecifier, ExportSpecifierList, Extends, For, FuncGlyph, HEREGEX_OMIT, HereComment, HoistTarget, IdentifierLiteral, If, ImportClause, ImportDeclaration, ImportDefaultSpecifier, ImportNamespaceSpecifier, ImportSpecifier, ImportSpecifierList, In, Index, InfinityLiteral, Interpolation, JS_FORBIDDEN, LEADING_BLANK_LINE, LEVEL_ACCESS, LEVEL_COND, LEVEL_LIST, LEVEL_OP, LEVEL_PAREN, LEVEL_TOP, LineComment, Literal, ModuleDeclaration, ModuleSpecifier, ModuleSpecifierList, NEGATE, NO, NaNLiteral, NullLiteral, NumberLiteral, Obj, Op, Param, Parens, PassthroughLiteral, PropertyName, Range, RegexLiteral, RegexWithInterpolations, Return, SIMPLENUM, SIMPLE_STRING_OMIT, STRING_OMIT, Scope, Slice, Splat, StatementLiteral, StringLiteral, StringWithInterpolations, Super, SuperCall, Switch, TAB, THIS, TRAILING_BLANK_LINE, TaggedTemplateCall, ThisLiteral, Throw, Try, UTILITIES, UndefinedLiteral, Value, While, YES, YieldReturn, addDataToNode, attachCommentsToNode, compact, del, ends, extend, flatten, fragmentsToText, hasLineComments, indentInitial, isFunction, isLiteralArguments, isLiteralThis, isNumber, isPlainObject, isUnassignable, locationDataToString, makeDelimitedLiteral, merge, moveComments, multident, replaceUnicodeCodePointEscapes, shouldCacheOrIsAssignable, some, starts, throwSyntaxError, unfoldSoak, unshiftAfterComments, utility,
     indexOf = [].indexOf,
     splice = [].splice,
     slice1 = [].slice;
@@ -16,7 +16,7 @@
   ({isUnassignable, JS_FORBIDDEN} = require('./lexer'));
 
   // Import the helpers we plan to use.
-  ({compact, flatten, extend, merge, del, starts, ends, some, addDataToNode, attachCommentsToNode, locationDataToString, throwSyntaxError, replaceUnicodeCodePointEscapes, locationDataToAst, astLocationFields, isFunction, isPlainObject, isNumber} = require('./helpers'));
+  ({compact, flatten, extend, merge, del, starts, ends, some, addDataToNode, attachCommentsToNode, locationDataToString, throwSyntaxError, replaceUnicodeCodePointEscapes, isFunction, isPlainObject, isNumber} = require('./helpers'));
 
   // Functions required by parser.
   exports.extend = extend;
@@ -361,165 +361,52 @@
 
       // Plain JavaScript object representation of the node, that can be serialized
       // as JSON. This is what the `ast` option in the Node API returns.
-      // We try to follow the [Babel AST spec](https://github.com/babel/babel/blob/master/packages/babylon/ast/spec.md)
+      // We try to follow the [Babel AST spec](https://github.com/babel/babel/blob/master/packages/babel-parser/ast/spec.md)
       // as closely as possible, for improved interoperability with other tools.
-      toAst(o, level) {
-        o = extend({}, o);
-        if (level) {
-          o.level = level;
-        }
-        return this.withAstLocationData(this.withAstType(this.getAstContent(o), o));
+      ast() {
+        // Every abstract syntax tree node object has four categories of properties:
+        // - type, stored in the `type` field and a string like `NumberLiteral`.
+        // - location data, stored in the `loc`, `start`, `end` and `range` fields.
+        // - properties specific to this node, like `parsedValue`.
+        // - properties that are themselves child nodes, like `body`.
+        // These fields are all intermixed in the Babel spec; `type` and `start` and
+        // `parsedValue` are all top level fields in the AST node object. We have
+        // separate methods for returning each category, that we merge together here.
+        return Object.assign({}, this.astProperties(), {
+          type: this.astType()
+        }, this.astLocationData());
       }
 
-      // By default, a node class's AST `type` is the class name
+      // By default, a node class has no specific properties.
+      astProperties() {
+        return {};
+      }
+
+      // By default, a node class’s AST `type` is its class name.
       astType() {
         return this.constructor.name;
       }
 
-      // Adds `type` to an AST.
-      // A node class typically defines `astType` (as a string or callback) if it
-      // needs to override the default-generated `type` (ie its constructor name)
-      withAstType(ast, o) {
-        var ref1;
-        if (!ast) {
-          return ast;
-        }
-        if (Array.isArray(ast)) {
-          return ast;
-        }
-        if (ast.type) {
-          return ast;
-        }
-        if (!(this.emptyAst || (function() {
-          var j, key, len1, ref1;
-          ref1 = Object.keys(ast);
-          for (j = 0, len1 = ref1.length; j < len1; j++) {
-            key = ref1[j];
-            if (indexOf.call(['comments', ...astLocationFields], key) < 0) {
-              return true;
+      // The AST location data is a rearranged version of our Jison location data,
+      // mutated into the structure that the Babel spec uses.
+      astLocationData() {
+        var first_column, first_line, last_column, last_line, range;
+        ({first_line, first_column, last_line, last_column, range} = this.locationData);
+        return {
+          loc: {
+            start: {
+              line: first_line + 1,
+              column: first_column
+            },
+            end: {
+              line: last_line + 1,
+              column: last_column + 1
             }
-          }
-        })())) {
-          return ast;
-        }
-        return merge(ast, {
-          type: (ref1 = typeof this.astType === "function" ? this.astType(o) : void 0) != null ? ref1 : this.astType
-        });
-      }
-
-      // Returns the "content" (ie not `type` or location data) of the AST for the node.
-      // By default, recursively generates AST nodes for `children`.
-      // To override, a node class can either:
-      //   - define `astChildren` to specify how to generate full child nodes, and/or
-      //     `astProps` to specify how to generate non-child-node fields
-      //   - override the `getAstContent()` method
-      getAstContent(o) {
-        return merge(this.getAstChildren(o), this.getAstProps(o));
-      }
-
-      // Returns the child-nodes fields of the AST node.
-      // By default, recursively generates AST nodes for `children`.
-      // To override, a node class defines `astChildren`, which can be either:
-      // - an array of property names (like `children`) which should have their generated
-      //   AST nodes included recursively.
-      // - an object whose keys are the desired AST field names and whose values are either:
-      //   - a string, which is the name of the node object property whose generated AST node
-      //     should be the corresponding value included in the AST
-      //   - an object with `key` and/or `level` fields. `key` corresponds to the simple string
-      //     value above, ie it's the name of a node object property. `level` is the desired
-      //     AST "compilation" level for that child node, eg `LEVEL_PAREN`
-      // - a callback function, which should return all the AST child-node fields
-      getAstChildren(o) {
-        var addChildAst, childAsts, children, j, key, len1, level, propName, ref1;
-        if (isFunction(this.astChildren)) {
-          return this.astChildren(o);
-        }
-        childAsts = {};
-        addChildAst = ({propName, key = propName, level}) => {
-          var item, val;
-          if (propName == null) {
-            propName = key;
-          }
-          val = this[propName];
-          return childAsts[key] = (function() {
-            var j, len1, results;
-            if (Array.isArray(val)) {
-              results = [];
-              for (j = 0, len1 = val.length; j < len1; j++) {
-                item = val[j];
-                results.push(item.toAst(o, level));
-              }
-              return results;
-            } else {
-              return val != null ? val.toAst(o, level) : void 0;
-            }
-          })();
+          },
+          range: [range[0], range[1]],
+          start: range[0],
+          end: range[1]
         };
-        children = (ref1 = this.astChildren) != null ? ref1 : this.children;
-        if (Array.isArray(children)) {
-          for (j = 0, len1 = children.length; j < len1; j++) {
-            propName = children[j];
-            addChildAst({propName});
-          }
-        } else {
-          for (key in children) {
-            propName = children[key];
-            if (isPlainObject(propName)) {
-              ({propName, level} = propName);
-            }
-            addChildAst({propName, key, level});
-          }
-        }
-        return childAsts;
-      }
-
-      // Returns the "simple" (ie non-child-nodes) fields of the AST node.
-      // By default, returns an empty object.
-      // To override, a node class defines `astProps`, which can be either:
-      // - an array of property names which should have their values included.
-      // - an object whose keys are the desired AST field names and whose values are
-      //   the corresponding "mapped" node class property names whose values should be included.
-      // - a callback function, which should return all the AST non-child-node fields
-      getAstProps(o) {
-        var astFields, j, key, len1, propName, ref1, ref2;
-        if (isFunction(this.astProps)) {
-          return this.astProps(o);
-        }
-        astFields = {};
-        if (Array.isArray(this.astProps)) {
-          ref1 = this.astProps;
-          for (j = 0, len1 = ref1.length; j < len1; j++) {
-            propName = ref1[j];
-            astFields[propName] = this[propName];
-          }
-        } else {
-          ref2 = this.astProps;
-          for (key in ref2) {
-            propName = ref2[key];
-            astFields[key] = this[propName];
-          }
-        }
-        return astFields;
-      }
-
-      withAstLocationData(ast, node) {
-        var item, locationData;
-        if (Array.isArray(ast)) {
-          return (function() {
-            var j, len1, results;
-            results = [];
-            for (j = 0, len1 = ast.length; j < len1; j++) {
-              item = ast[j];
-              results.push(this.withAstLocationData(item, node));
-            }
-            return results;
-          }).call(this);
-        }
-        ({locationData} = node != null ? node : this);
-        if (!(locationData && ast && (ast.start == null))) {
-          return ast;
-        }
-        return merge(ast, locationDataToAst(locationData));
       }
 
       // Passes each child to a function, breaking when the function returns `false`.
@@ -654,8 +541,6 @@
       }
 
     };
-
-    Base.prototype.astProps = [];
 
     // Default implementations of the common node properties and methods. Nodes
     // will override these with custom logic, if needed.
@@ -1176,6 +1061,14 @@
         return new Block(nodes);
       }
 
+      astProperties() {
+        return {
+          expressions: this.expressions.map((child) => {
+            return child.ast();
+          })
+        };
+      }
+
     };
 
     Block.prototype.children = ['expressions'];
@@ -1204,6 +1097,12 @@
         return [this.makeCode(this.value)];
       }
 
+      astProperties() {
+        return {
+          value: this.value
+        };
+      }
+
       toString() {
         // This is only intended for debugging.
         return ` ${this.isStatement() ? super.toString() : this.constructor.name}: ${this.value}`;
@@ -1213,95 +1112,84 @@
 
     Literal.prototype.shouldCache = NO;
 
-    Literal.prototype.astProps = ['value'];
-
     return Literal;
 
   }).call(this);
 
-  exports.NumberLiteral = NumberLiteral = (function() {
-    class NumberLiteral extends Literal {
-      constructor(value1, {parsedValue} = {}) {
-        super();
-        this.value = value1;
-        this.parsedValue = parsedValue;
-        if (this.parsedValue == null) {
-          if (isNumber(this.value)) {
-            this.parsedValue = this.value;
-            this.value = `${this.value}`;
-          } else {
-            this.parsedValue = Number(this.value);
-          }
-        }
-      }
-
-      astProps() {
-        return {
-          value: this.parsedValue,
-          extra: {
-            rawValue: this.parsedValue,
-            raw: this.value
-          }
-        };
-      }
-
-    };
-
-    NumberLiteral.prototype.astType = 'NumericLiteral';
-
-    return NumberLiteral;
-
-  }).call(this);
-
-  exports.InfinityLiteral = InfinityLiteral = (function() {
-    class InfinityLiteral extends NumberLiteral {
-      compileNode() {
-        return [this.makeCode('2e308')];
-      }
-
-      astProps() {
-        return {
-          name: 'Infinity'
-        };
-      }
-
-    };
-
-    InfinityLiteral.prototype.astType = 'Identifier';
-
-    return InfinityLiteral;
-
-  }).call(this);
-
-  exports.NaNLiteral = NaNLiteral = (function() {
-    class NaNLiteral extends NumberLiteral {
-      constructor() {
-        super('NaN');
-      }
-
-      compileNode(o) {
-        var code;
-        code = [this.makeCode('0/0')];
-        if (o.level >= LEVEL_OP) {
-          return this.wrapInParentheses(code);
+  exports.NumberLiteral = NumberLiteral = class NumberLiteral extends Literal {
+    constructor(value1, {parsedValue} = {}) {
+      super();
+      this.value = value1;
+      this.parsedValue = parsedValue;
+      if (this.parsedValue == null) {
+        if (isNumber(this.value)) {
+          this.parsedValue = this.value;
+          this.value = `${this.value}`;
         } else {
-          return code;
+          this.parsedValue = Number(this.value);
         }
       }
+    }
 
-      astProps() {
-        return {
-          name: 'NaN'
-        };
+    astType() {
+      return 'NumericLiteral';
+    }
+
+    astProperties() {
+      return {
+        value: this.parsedValue,
+        extra: {
+          rawValue: this.parsedValue,
+          raw: this.value
+        }
+      };
+    }
+
+  };
+
+  exports.InfinityLiteral = InfinityLiteral = class InfinityLiteral extends NumberLiteral {
+    compileNode() {
+      return [this.makeCode('2e308')];
+    }
+
+    astType() {
+      return 'Identifier';
+    }
+
+    astProperties() {
+      return {
+        name: 'Infinity'
+      };
+    }
+
+  };
+
+  exports.NaNLiteral = NaNLiteral = class NaNLiteral extends NumberLiteral {
+    constructor() {
+      super('NaN');
+    }
+
+    compileNode(o) {
+      var code;
+      code = [this.makeCode('0/0')];
+      if (o.level >= LEVEL_OP) {
+        return this.wrapInParentheses(code);
+      } else {
+        return code;
       }
+    }
 
-    };
+    astType() {
+      return 'Identifier';
+    }
 
-    NaNLiteral.prototype.astType = 'Identifier';
+    astProperties() {
+      return {
+        name: 'NaN'
+      };
+    }
 
-    return NaNLiteral;
-
-  }).call(this);
+  };
 
   exports.StringLiteral = StringLiteral = class StringLiteral extends Literal {
     constructor(originalValue, {
@@ -1418,13 +1306,15 @@
         }
       }
 
+      astProperties() {
+        return {
+          name: this.value
+        };
+      }
+
     };
 
     IdentifierLiteral.prototype.isAssignable = YES;
-
-    IdentifierLiteral.prototype.astProps = {
-      name: 'value'
-    };
 
     return IdentifierLiteral;
 
@@ -1484,66 +1374,57 @@
 
   }).call(this);
 
-  exports.ThisLiteral = ThisLiteral = (function() {
-    class ThisLiteral extends Literal {
-      constructor(value) {
-        super('this');
-        this.shorthand = value === '@';
-      }
+  exports.ThisLiteral = ThisLiteral = class ThisLiteral extends Literal {
+    constructor(value) {
+      super('this');
+      this.shorthand = value === '@';
+    }
 
-      compileNode(o) {
-        var code, ref1;
-        code = ((ref1 = o.scope.method) != null ? ref1.bound : void 0) ? o.scope.method.context : this.value;
-        return [this.makeCode(code)];
-      }
+    compileNode(o) {
+      var code, ref1;
+      code = ((ref1 = o.scope.method) != null ? ref1.bound : void 0) ? o.scope.method.context : this.value;
+      return [this.makeCode(code)];
+    }
 
-    };
+    astType() {
+      return 'ThisExpression';
+    }
 
-    ThisLiteral.prototype.astType = 'ThisExpression';
+    astProperties() {
+      return {
+        shorthand: this.shorthand
+      };
+    }
 
-    ThisLiteral.prototype.astProps = ['shorthand'];
+  };
 
-    return ThisLiteral;
+  exports.UndefinedLiteral = UndefinedLiteral = class UndefinedLiteral extends Literal {
+    constructor() {
+      super('undefined');
+    }
 
-  }).call(this);
+    compileNode(o) {
+      return [this.makeCode(o.level >= LEVEL_ACCESS ? '(void 0)' : 'void 0')];
+    }
 
-  exports.UndefinedLiteral = UndefinedLiteral = (function() {
-    class UndefinedLiteral extends Literal {
-      constructor() {
-        super('undefined');
-      }
+    astType() {
+      return 'Identifier';
+    }
 
-      compileNode(o) {
-        return [this.makeCode(o.level >= LEVEL_ACCESS ? '(void 0)' : 'void 0')];
-      }
+    astProperties() {
+      return {
+        name: this.value
+      };
+    }
 
-    };
+  };
 
-    UndefinedLiteral.prototype.astType = 'Identifier';
+  exports.NullLiteral = NullLiteral = class NullLiteral extends Literal {
+    constructor() {
+      super('null');
+    }
 
-    UndefinedLiteral.prototype.astProps = {
-      name: 'value'
-    };
-
-    return UndefinedLiteral;
-
-  }).call(this);
-
-  exports.NullLiteral = NullLiteral = (function() {
-    class NullLiteral extends Literal {
-      constructor() {
-        super('null');
-      }
-
-    };
-
-    NullLiteral.prototype.astProps = [];
-
-    NullLiteral.prototype.emptyAst = true;
-
-    return NullLiteral;
-
-  }).call(this);
+  };
 
   exports.BooleanLiteral = BooleanLiteral = class BooleanLiteral extends Literal {
     constructor(value, {originalValue} = {}) {
@@ -1554,7 +1435,7 @@
       }
     }
 
-    astProps(o) {
+    astProperties() {
       return {
         value: this.value === 'true' ? true : false,
         name: this.originalValue
@@ -1845,11 +1726,6 @@
         return fragments;
       }
 
-      getAstContent(o) {
-        return this.base.toAst(o);
-      }
-
-      // TODO: will include AST generation for properties here
       checkNewTarget(o) {
         if (!(this.base instanceof IdentifierLiteral && this.base.value === 'new' && this.properties.length)) {
           return;
@@ -1902,6 +1778,14 @@
         } else {
           return this.error('tried to assign to unassignable value');
         }
+      }
+
+      astType() {
+        return this.base.astType();
+      }
+
+      astProperties(o) {
+        return this.base.ast(o);
       }
 
     };

--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -1784,8 +1784,8 @@
         return this.base.astType();
       }
 
-      astProperties(o) {
-        return this.base.ast(o);
+      astProperties() {
+        return this.base.ast();
       }
 
     };

--- a/src/coffeescript.coffee
+++ b/src/coffeescript.coffee
@@ -98,7 +98,7 @@ exports.compile = compile = withPrettyErrors (code, options = {}) ->
   # If all that was requested was a POJO representation of the nodes, e.g.
   # the abstract syntax tree (AST), we can stop now and just return that.
   if options.ast
-    return nodes.toAst options
+    return nodes.ast options
 
   fragments = nodes.compileToFragments options
 

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -248,23 +248,6 @@ exports.nameWhitespaceCharacter = (string) ->
     when '\t' then 'tab'
     else string
 
-exports.locationDataToAst = ({first_line, first_column, last_line, last_column, range}) ->
-  loc:
-    start:
-      line: first_line + 1
-      column: first_column
-    end:
-      line: last_line + 1
-      column: last_column + 1
-  range: [
-    range[0]
-    range[1]
-  ]
-  start: range[0]
-  end: range[1]
-
-exports.astLocationFields = ['loc', 'range', 'start', 'end']
-
 exports.isFunction = (obj) -> Object::toString.call(obj) is '[object Function]'
 exports.isNumber = isNumber = (obj) -> Object::toString.call(obj) is '[object Number]'
 exports.isString = isString = (obj) -> Object::toString.call(obj) is '[object String]'

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -269,7 +269,7 @@ exports.Base = class Base
 
   # Plain JavaScript object representation of the node, that can be serialized
   # as JSON. This is what the `ast` option in the Node API returns.
-  # We try to follow the [Babel AST spec](https://github.com/babel/babel/blob/master/packages/babylon/ast/spec.md)
+  # We try to follow the [Babel AST spec](https://github.com/babel/babel/blob/master/packages/babel-parser/ast/spec.md)
   # as closely as possible, for improved interoperability with other tools.
   toAst: (o, level) ->
     o = Object.assign {}, o

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -272,7 +272,7 @@ exports.Base = class Base
   # We try to follow the [Babel AST spec](https://github.com/babel/babel/blob/master/packages/babylon/ast/spec.md)
   # as closely as possible, for improved interoperability with other tools.
   toAst: (o, level) ->
-    o = extend {}, o
+    o = Object.assign {}, o
     o.level = level if level
     @withAstLocationData @withAstType @getAstContent(o), o
 
@@ -289,7 +289,7 @@ exports.Base = class Base
     return ast unless @emptyAst or do ->
       return yes for key in Object.keys(ast) when key not in ['comments', astLocationFields...]
 
-    merge ast,
+    Object.assign ast,
       type: @astType?(o) ? @astType
 
   # Returns the "content" (ie not `type` or location data) of the AST for the node.
@@ -299,10 +299,7 @@ exports.Base = class Base
   #     `astProps` to specify how to generate non-child-node fields
   #   - override the `getAstContent()` method
   getAstContent: (o) ->
-    merge(
-      @getAstChildren o
-      @getAstProps o
-    )
+    Object.assign {}, @getAstChildren(o), @getAstProps(o)
 
   # Returns the child-nodes fields of the AST node.
   # By default, recursively generates AST nodes for `children`.
@@ -360,7 +357,7 @@ exports.Base = class Base
     return (@withAstLocationData(item, node) for item in ast) if Array.isArray ast
     {locationData} = node ? @
     return ast unless locationData and ast and not ast.start?
-    merge ast, locationDataToAst locationData
+    Object.assign ast, locationDataToAst locationData
 
   # Passes each child to a function, breaking when the function returns `false`.
   eachChild: (func) ->

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -1182,8 +1182,8 @@ exports.Value = class Value extends Base
   astType: ->
     @base.astType()
 
-  astProperties: (o) ->
-    @base.ast o
+  astProperties: ->
+    @base.ast()
 
 #### HereComment
 

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -12,7 +12,6 @@ Error.stackTraceLimit = Infinity
 {compact, flatten, extend, merge, del, starts, ends, some,
 addDataToNode, attachCommentsToNode, locationDataToString,
 throwSyntaxError, replaceUnicodeCodePointEscapes,
-locationDataToAst, astLocationFields,
 isFunction, isPlainObject, isNumber} = require './helpers'
 
 # Functions required by parser.
@@ -271,93 +270,41 @@ exports.Base = class Base
   # as JSON. This is what the `ast` option in the Node API returns.
   # We try to follow the [Babel AST spec](https://github.com/babel/babel/blob/master/packages/babel-parser/ast/spec.md)
   # as closely as possible, for improved interoperability with other tools.
-  toAst: (o, level) ->
-    o = Object.assign {}, o
-    o.level = level if level
-    @withAstLocationData @withAstType @getAstContent(o), o
+  ast: ->
+    # Every abstract syntax tree node object has four categories of properties:
+    # - type, stored in the `type` field and a string like `NumberLiteral`.
+    # - location data, stored in the `loc`, `start`, `end` and `range` fields.
+    # - properties specific to this node, like `parsedValue`.
+    # - properties that are themselves child nodes, like `body`.
+    # These fields are all intermixed in the Babel spec; `type` and `start` and
+    # `parsedValue` are all top level fields in the AST node object. We have
+    # separate methods for returning each category, that we merge together here.
+    Object.assign {}, @astProperties(), {type: @astType()}, @astLocationData()
 
-  # By default, a node class's AST `type` is the class name
+  # By default, a node class has no specific properties.
+  astProperties: -> {}
+
+  # By default, a node class’s AST `type` is its class name.
   astType: -> @constructor.name
 
-  # Adds `type` to an AST.
-  # A node class typically defines `astType` (as a string or callback) if it
-  # needs to override the default-generated `type` (ie its constructor name)
-  withAstType: (ast, o) ->
-    return ast unless ast
-    return ast if Array.isArray ast
-    return ast if ast.type
-    return ast unless @emptyAst or do ->
-      return yes for key in Object.keys(ast) when key not in ['comments', astLocationFields...]
-
-    Object.assign ast,
-      type: @astType?(o) ? @astType
-
-  # Returns the "content" (ie not `type` or location data) of the AST for the node.
-  # By default, recursively generates AST nodes for `children`.
-  # To override, a node class can either:
-  #   - define `astChildren` to specify how to generate full child nodes, and/or
-  #     `astProps` to specify how to generate non-child-node fields
-  #   - override the `getAstContent()` method
-  getAstContent: (o) ->
-    Object.assign {}, @getAstChildren(o), @getAstProps(o)
-
-  # Returns the child-nodes fields of the AST node.
-  # By default, recursively generates AST nodes for `children`.
-  # To override, a node class defines `astChildren`, which can be either:
-  # - an array of property names (like `children`) which should have their generated
-  #   AST nodes included recursively.
-  # - an object whose keys are the desired AST field names and whose values are either:
-  #   - a string, which is the name of the node object property whose generated AST node
-  #     should be the corresponding value included in the AST
-  #   - an object with `key` and/or `level` fields. `key` corresponds to the simple string
-  #     value above, ie it's the name of a node object property. `level` is the desired
-  #     AST "compilation" level for that child node, eg `LEVEL_PAREN`
-  # - a callback function, which should return all the AST child-node fields
-  getAstChildren: (o) ->
-    return @astChildren o if isFunction @astChildren
-    childAsts = {}
-    addChildAst = ({propName, key = propName, level}) =>
-      propName ?= key
-      val = @[propName]
-      childAsts[key] =
-        if Array.isArray val
-          item.toAst o, level for item in val
-        else
-          val?.toAst o, level
-
-    children = @astChildren ? @children
-    if Array.isArray children
-      addChildAst {propName} for propName in children
-    else
-      for key, propName of children
-        {propName, level} = propName if isPlainObject propName
-        addChildAst {propName, key, level}
-    childAsts
-
-  astProps: []
-  # Returns the "simple" (ie non-child-nodes) fields of the AST node.
-  # By default, returns an empty object.
-  # To override, a node class defines `astProps`, which can be either:
-  # - an array of property names which should have their values included.
-  # - an object whose keys are the desired AST field names and whose values are
-  #   the corresponding "mapped" node class property names whose values should be included.
-  # - a callback function, which should return all the AST non-child-node fields
-  getAstProps: (o) ->
-    return @astProps o if isFunction @astProps
-    astFields = {}
-    if Array.isArray @astProps
-      for propName in @astProps
-        astFields[propName] = @[propName]
-    else
-      for key, propName of @astProps
-        astFields[key] = @[propName]
-    astFields
-
-  withAstLocationData: (ast, node) ->
-    return (@withAstLocationData(item, node) for item in ast) if Array.isArray ast
-    {locationData} = node ? @
-    return ast unless locationData and ast and not ast.start?
-    Object.assign ast, locationDataToAst locationData
+  # The AST location data is a rearranged version of our Jison location data,
+  # mutated into the structure that the Babel spec uses.
+  astLocationData: ->
+    {first_line, first_column, last_line, last_column, range} = @locationData
+    return
+      loc:
+        start:
+          line: first_line + 1
+          column: first_column
+        end:
+          line: last_line + 1
+          column: last_column + 1
+      range: [
+        range[0]
+        range[1]
+      ]
+      start: range[0]
+      end: range[1]
 
   # Passes each child to a function, breaking when the function returns `false`.
   eachChild: (func) ->
@@ -814,6 +761,9 @@ exports.Block = class Block extends Base
     return nodes[0] if nodes.length is 1 and nodes[0] instanceof Block
     new Block nodes
 
+  astProperties: ->
+    expressions: @expressions.map (child) => child.ast()
+
 #### Literal
 
 # `Literal` is a base class for static values that can be passed through
@@ -831,7 +781,8 @@ exports.Literal = class Literal extends Base
   compileNode: (o) ->
     [@makeCode @value]
 
-  astProps: ['value']
+  astProperties: ->
+    value: @value
 
   toString: ->
     # This is only intended for debugging.
@@ -847,8 +798,9 @@ exports.NumberLiteral = class NumberLiteral extends Literal
       else
         @parsedValue = Number @value
 
-  astType: 'NumericLiteral'
-  astProps: ->
+  astType: -> 'NumericLiteral'
+
+  astProperties: ->
     value: @parsedValue
     extra:
       rawValue: @parsedValue
@@ -858,8 +810,9 @@ exports.InfinityLiteral = class InfinityLiteral extends NumberLiteral
   compileNode: ->
     [@makeCode '2e308']
 
-  astType: 'Identifier'
-  astProps: ->
+  astType: -> 'Identifier'
+
+  astProperties: ->
     name: 'Infinity'
 
 exports.NaNLiteral = class NaNLiteral extends NumberLiteral
@@ -870,8 +823,9 @@ exports.NaNLiteral = class NaNLiteral extends NumberLiteral
     code = [@makeCode '0/0']
     if o.level >= LEVEL_OP then @wrapInParentheses code else code
 
-  astType: 'Identifier'
-  astProps: ->
+  astType: -> 'Identifier'
+
+  astProperties: ->
     name: 'NaN'
 
 exports.StringLiteral = class StringLiteral extends Literal
@@ -950,8 +904,8 @@ exports.IdentifierLiteral = class IdentifierLiteral extends Literal
     else
       'Identifier'
 
-  astProps:
-    name: 'value'
+  astProperties: ->
+    name: @value
 
 exports.CSXTag = class CSXTag extends IdentifierLiteral
 
@@ -989,8 +943,10 @@ exports.ThisLiteral = class ThisLiteral extends Literal
     code = if o.scope.method?.bound then o.scope.method.context else @value
     [@makeCode code]
 
-  astType: 'ThisExpression'
-  astProps: ['shorthand']
+  astType: -> 'ThisExpression'
+
+  astProperties: ->
+    shorthand: @shorthand
 
 exports.UndefinedLiteral = class UndefinedLiteral extends Literal
   constructor: ->
@@ -999,23 +955,21 @@ exports.UndefinedLiteral = class UndefinedLiteral extends Literal
   compileNode: (o) ->
     [@makeCode if o.level >= LEVEL_ACCESS then '(void 0)' else 'void 0']
 
-  astType: 'Identifier'
-  astProps:
-    name: 'value'
+  astType: -> 'Identifier'
+
+  astProperties: ->
+    name: @value
 
 exports.NullLiteral = class NullLiteral extends Literal
   constructor: ->
     super 'null'
-
-  astProps: []
-  emptyAst: yes
 
 exports.BooleanLiteral = class BooleanLiteral extends Literal
   constructor: (value, {@originalValue} = {}) ->
     super value
     @originalValue ?= @value
 
-  astProps: (o) ->
+  astProperties: ->
     value: if @value is 'true' then yes else no
     name: @originalValue
 
@@ -1191,10 +1145,6 @@ exports.Value = class Value extends Base
 
     fragments
 
-  getAstContent: (o) ->
-    @base.toAst o
-    # TODO: will include AST generation for properties here
-
   checkNewTarget: (o) ->
     return unless @base instanceof IdentifierLiteral and @base.value is 'new' and @properties.length
     if @properties[0] instanceof Access and @properties[0].name.value is 'target'
@@ -1228,6 +1178,12 @@ exports.Value = class Value extends Base
       @base.eachName iterator
     else
       @error 'tried to assign to unassignable value'
+
+  astType: ->
+    @base.astType()
+
+  astProperties: (o) ->
+    @base.ast o
 
 #### HereComment
 

--- a/test/abstract_syntax_tree_location_data.coffee
+++ b/test/abstract_syntax_tree_location_data.coffee
@@ -1,8 +1,29 @@
-testExpression = expressionAstMatchesObject
+# Astract Syntax Tree location data
+# ---------------------------------
+
+testAstLocationData = (code, expected) ->
+  ast = CoffeeScript.compile code, ast: yes
+  # Pull the node we’re testing out of the root `Block` node’s first child.
+  node = ast.expressions[0]
+
+  eq node.start, expected.start, \
+    "Expected location start #{reset}#{node.start}#{red} to equal #{reset}#{expected.start}#{red}"
+  eq node.end, expected.end, \
+    "Expected location end #{reset}#{node.end}#{red} to equal #{reset}#{expected.end}#{red}"
+  arrayEq node.range, expected.range, \
+    "Expected location range #{reset}#{JSON.stringify node.range}#{red} to equal #{reset}#{JSON.stringify expected.range}#{red}"
+  eq node.loc.start.line, expected.loc.start.line, \
+    "Expected location start line #{reset}#{node.loc.start.line}#{red} to equal #{reset}#{expected.loc.start.line}#{red}"
+  eq node.loc.start.column, expected.loc.start.column, \
+    "Expected location start column #{reset}#{node.loc.start.column}#{red} to equal #{reset}#{expected.loc.start.column}#{red}"
+  eq node.loc.end.line, expected.loc.end.line, \
+    "Expected location end line #{reset}#{node.loc.end.line}#{red} to equal #{reset}#{expected.loc.end.line}#{red}"
+  eq node.loc.end.column, expected.loc.end.column, \
+    "Expected location end column #{reset}#{node.loc.end.column}#{red} to equal #{reset}#{expected.loc.end.column}#{red}"
+
 
 test "AST location data as expected for NumberLiteral node", ->
-  testExpression '42',
-    type: 'NumericLiteral'
+  testAstLocationData '42',
     start: 0
     end: 2
     range: [0, 2]
@@ -15,8 +36,7 @@ test "AST location data as expected for NumberLiteral node", ->
         column: 2
 
 test "AST location data as expected for InfinityLiteral node", ->
-  testExpression 'Infinity',
-    type: 'Identifier'
+  testAstLocationData 'Infinity',
     start: 0
     end: 8
     range: [0, 8]
@@ -29,8 +49,7 @@ test "AST location data as expected for InfinityLiteral node", ->
         column: 8
 
 test "AST location data as expected for NaNLiteral node", ->
-  testExpression 'NaN',
-    type: 'Identifier'
+  testAstLocationData 'NaN',
     start: 0
     end: 3
     range: [0, 3]
@@ -43,8 +62,7 @@ test "AST location data as expected for NaNLiteral node", ->
         column: 3
 
 test "AST location data as expected for IdentifierLiteral node", ->
-  testExpression 'id',
-    type: 'Identifier'
+  testAstLocationData 'id',
     start: 0
     end: 2
     range: [0, 2]
@@ -57,8 +75,7 @@ test "AST location data as expected for IdentifierLiteral node", ->
         column: 2
 
 test "AST location data as expected for StatementLiteral node", ->
-  testExpression 'break',
-    type: 'BreakStatement'
+  testAstLocationData 'break',
     start: 0
     end: 5
     range: [0, 5]
@@ -70,8 +87,7 @@ test "AST location data as expected for StatementLiteral node", ->
         line: 1
         column: 5
 
-  testExpression 'continue',
-    type: 'ContinueStatement'
+  testAstLocationData 'continue',
     start: 0
     end: 8
     range: [0, 8]
@@ -83,8 +99,7 @@ test "AST location data as expected for StatementLiteral node", ->
         line: 1
         column: 8
 
-  testExpression 'debugger',
-    type: 'DebuggerStatement'
+  testAstLocationData 'debugger',
     start: 0
     end: 8
     range: [0, 8]
@@ -97,8 +112,7 @@ test "AST location data as expected for StatementLiteral node", ->
         column: 8
 
 test "AST location data as expected for ThisLiteral node", ->
-  testExpression 'this',
-    type: 'ThisExpression'
+  testAstLocationData 'this',
     start: 0
     end: 4
     range: [0, 4]
@@ -111,8 +125,7 @@ test "AST location data as expected for ThisLiteral node", ->
         column: 4
 
 test "AST location data as expected for UndefinedLiteral node", ->
-  testExpression 'undefined',
-    type: 'Identifier'
+  testAstLocationData 'undefined',
     start: 0
     end: 9
     range: [0, 9]
@@ -125,8 +138,7 @@ test "AST location data as expected for UndefinedLiteral node", ->
         column: 9
 
 test "AST location data as expected for NullLiteral node", ->
-  testExpression 'null',
-    type: 'NullLiteral'
+  testAstLocationData 'null',
     start: 0
     end: 4
     range: [0, 4]
@@ -139,8 +151,7 @@ test "AST location data as expected for NullLiteral node", ->
         column: 4
 
 test "AST location data as expected for BooleanLiteral node", ->
-  testExpression 'true',
-    type: 'BooleanLiteral'
+  testAstLocationData 'true',
     start: 0
     end: 4
     range: [0, 4]

--- a/test/abstract_syntax_tree_location_data.coffee
+++ b/test/abstract_syntax_tree_location_data.coffee
@@ -6,6 +6,11 @@ testAstLocationData = (code, expected) ->
   # Pull the node we’re testing out of the root `Block` node’s first child.
   node = ast.expressions[0]
 
+  # Even though it’s not part of the location data, check the type to ensure
+  # that we’re testing the node we think we are.
+  eq node.type, expected.type, \
+    "Expected AST node type #{reset}#{node.type}#{red} to equal #{reset}#{expected.type}#{red}"
+
   eq node.start, expected.start, \
     "Expected location start #{reset}#{node.start}#{red} to equal #{reset}#{expected.start}#{red}"
   eq node.end, expected.end, \
@@ -24,6 +29,7 @@ testAstLocationData = (code, expected) ->
 
 test "AST location data as expected for NumberLiteral node", ->
   testAstLocationData '42',
+    type: 'NumericLiteral'
     start: 0
     end: 2
     range: [0, 2]
@@ -37,6 +43,7 @@ test "AST location data as expected for NumberLiteral node", ->
 
 test "AST location data as expected for InfinityLiteral node", ->
   testAstLocationData 'Infinity',
+    type: 'Identifier'
     start: 0
     end: 8
     range: [0, 8]
@@ -50,6 +57,7 @@ test "AST location data as expected for InfinityLiteral node", ->
 
 test "AST location data as expected for NaNLiteral node", ->
   testAstLocationData 'NaN',
+    type: 'Identifier'
     start: 0
     end: 3
     range: [0, 3]
@@ -63,6 +71,7 @@ test "AST location data as expected for NaNLiteral node", ->
 
 test "AST location data as expected for IdentifierLiteral node", ->
   testAstLocationData 'id',
+    type: 'Identifier'
     start: 0
     end: 2
     range: [0, 2]
@@ -76,6 +85,7 @@ test "AST location data as expected for IdentifierLiteral node", ->
 
 test "AST location data as expected for StatementLiteral node", ->
   testAstLocationData 'break',
+    type: 'BreakStatement'
     start: 0
     end: 5
     range: [0, 5]
@@ -88,6 +98,7 @@ test "AST location data as expected for StatementLiteral node", ->
         column: 5
 
   testAstLocationData 'continue',
+    type: 'ContinueStatement'
     start: 0
     end: 8
     range: [0, 8]
@@ -100,6 +111,7 @@ test "AST location data as expected for StatementLiteral node", ->
         column: 8
 
   testAstLocationData 'debugger',
+    type: 'DebuggerStatement'
     start: 0
     end: 8
     range: [0, 8]
@@ -113,6 +125,7 @@ test "AST location data as expected for StatementLiteral node", ->
 
 test "AST location data as expected for ThisLiteral node", ->
   testAstLocationData 'this',
+    type: 'ThisExpression'
     start: 0
     end: 4
     range: [0, 4]
@@ -126,6 +139,7 @@ test "AST location data as expected for ThisLiteral node", ->
 
 test "AST location data as expected for UndefinedLiteral node", ->
   testAstLocationData 'undefined',
+    type: 'Identifier'
     start: 0
     end: 9
     range: [0, 9]
@@ -139,6 +153,7 @@ test "AST location data as expected for UndefinedLiteral node", ->
 
 test "AST location data as expected for NullLiteral node", ->
   testAstLocationData 'null',
+    type: 'NullLiteral'
     start: 0
     end: 4
     range: [0, 4]
@@ -152,6 +167,7 @@ test "AST location data as expected for NullLiteral node", ->
 
 test "AST location data as expected for BooleanLiteral node", ->
   testAstLocationData 'true',
+    type: 'BooleanLiteral'
     start: 0
     end: 4
     range: [0, 4]

--- a/test/support/helpers.coffee
+++ b/test/support/helpers.coffee
@@ -51,22 +51,21 @@ getExpressionAst = (code) -> getAstExpressions(code)[0]
 # Recursively compare all values of enumerable properties of `expected` with
 # those of `actual`. Use `looseArray` helper function to skip array length
 # comparison.
-
-exports.deepStrictEqualExpectedProps = deepStrictEqualExpectedProps = (actual, expected) ->
-  white = (text, values...) -> (text[i] + "#{reset}#{v}#{red}" for v, i in values).join('') + text[i]
+exports.deepStrictEqualExpectedProperties = deepStrictEqualExpectedProperties = (actual, expected) ->
+  white = (text, values...) -> (text[i] + "#{reset}#{value}#{red}" for value, i in values).join('') + text[i]
   eq actual.length, expected.length if expected instanceof Array and not expected.loose
-  for k , v of expected
-    if 'object' is typeof v
-      fail white"`actual` misses #{k} property." unless k of actual
-      deepStrictEqualExpectedProps actual[k], v
+  for key, val of expected
+    if 'object' is typeof val
+      fail white"Property #{key} expected, but was missing" unless actual[key]
+      deepStrictEqualExpectedProperties actual[key], val
     else
-      eq actual[k], v, white"Property #{k}: expected #{actual[k]} to equal #{v}"
+      eq actual[key], val, white"Property #{key}: expected #{actual[key]} to equal #{val}"
   actual
 
 exports.expressionAstMatchesObject = (code, expected) ->
   ast = getExpressionAst code
   if expected?
-    deepStrictEqualExpectedProps ast, expected
+    deepStrictEqualExpectedProperties ast, expected
   else
     console.log require('util').inspect ast,
       depth: 10

--- a/test/support/helpers.coffee
+++ b/test/support/helpers.coffee
@@ -38,35 +38,3 @@ exports.eqJS = (input, expectedOutput, msg) ->
   ok egal(expectedOutput, actualOutput), msg or diffOutput expectedOutput, actualOutput
 
 exports.isWindows = -> process.platform is 'win32'
-
-# Helpers to get AST nodes for a string of code. The root node is always a
-# `Block` node, so for brevity in the tests return its children from
-# `expressions`.
-getAstExpressions = (code) ->
-  ast = CoffeeScript.compile code, ast: yes
-  ast.expressions
-
-getExpressionAst = (code) -> getAstExpressions(code)[0]
-
-# Recursively compare all values of enumerable properties of `expected` with
-# those of `actual`. Use `looseArray` helper function to skip array length
-# comparison.
-exports.deepStrictEqualExpectedProperties = deepStrictEqualExpectedProperties = (actual, expected) ->
-  white = (text, values...) -> (text[i] + "#{reset}#{value}#{red}" for value, i in values).join('') + text[i]
-  eq actual.length, expected.length if expected instanceof Array and not expected.loose
-  for key, val of expected
-    if 'object' is typeof val
-      fail white"Property #{key} expected, but was missing" unless actual[key]
-      deepStrictEqualExpectedProperties actual[key], val
-    else
-      eq actual[key], val, white"Property #{key}: expected #{actual[key]} to equal #{val}"
-  actual
-
-exports.expressionAstMatchesObject = (code, expected) ->
-  ast = getExpressionAst code
-  if expected?
-    deepStrictEqualExpectedProperties ast, expected
-  else
-    console.log require('util').inspect ast,
-      depth: 10
-      colors: yes


### PR DESCRIPTION
Sorry this has taken so long, I needed to find the time to really dig into this. So, code like this:

```coffee
  withAstType: (ast, o) ->
    return ast unless ast
    return ast if Array.isArray ast
    return ast if ast.type
    return ast unless @emptyAst or do ->
      return yes for key in Object.keys(ast) when key not in ['comments', astLocationFields...]

    merge ast,
      type: @astType?(o) ? @astType
```

Was bothering me. On a basic level, we shouldn’t be passing around the AST that we’re generating, for other functions to iterate over it and mutate it. That would be hell to debug whenever the final AST output isn’t what we’re expecting. But on the broader level, this doesn’t follow object-oriented principles. We shouldn’t be passing in an output object into each class for the class to decorate the nodes of the output with extra properties. This is a helper function attached to a class as a method.

All the base AST methods felt like this to me, but rather than giving you annoying feedback like “make this more object-oriented” or “follow the pattern of the node classes” I thought I should take a crack at refactoring it myself. Which I did, and the tests still pass. So here’s the basic idea:

```coffee
  ast: ->
    # Every abstract syntax tree node object has four categories of properties:
    # - type, stored in the `type` field and a string like `NumberLiteral`.
    # - location data, stored in the `loc`, `start`, `end` and `range` fields.
    # - properties specific to this node, like `parsedValue`.
    # - properties that are themselves child nodes, like `body`.
    # These fields are all intermixed in the Babel spec; `type` and `start` and
    # `parsedValue` are all top level fields in the AST node object. We have
    # separate methods for returning each category, that we merge together here.
    Object.assign {}, @astProperties(), {type: @astType()}, @astLocationData()
```

I renamed `toAst` to `ast` so that all our AST-related methods start with `ast`. Still not happy with naming but that’s another story. The basic idea here is that there are three methods that return all the parts of an AST object: `astProperties`, `astType` and `astLocationData`. Of the three, `astType` returns a string and the others return objects—always. No complicated `if` trees checking if `astProperties` is a function or array or object, it should just always be a function that always returns an object, and that’s it.

And there’s no looping in the base class. Children get added by overriding `astProperties` for nodes that have child nodes, such as `Block`:

```coffee
  astProperties: ->
    expressions: @expressions.map (child) => child.ast()
```

And that’s it. Thoughts?